### PR TITLE
NCIOCPL-19 | Remove SayHelloWorld() method

### DIFF
--- a/src/NCI.OCPL.Api.Glossary/Controllers/TermController.cs
+++ b/src/NCI.OCPL.Api.Glossary/Controllers/TermController.cs
@@ -23,15 +23,6 @@ namespace NCI.OCPL.Api.Glossary.Controllers
         }
 
         /// <summary>
-        /// A temporary method added to check the health of the controller.
-        /// </summary>
-        [HttpGet("hello")]
-        public string SayHelloWorld()
-        {
-            return "Hello New World";
-        }
-
-        /// <summary>
         /// Get the Glossary Term based on Id.
         /// </summary>
         /// <returns>GlossaryTerm object</returns>

--- a/test/NCI.OCPL.Api.Glossary.Tests/Tests/Controllers/TermControllerTest.cs
+++ b/test/NCI.OCPL.Api.Glossary.Tests/Tests/Controllers/TermControllerTest.cs
@@ -42,25 +42,5 @@ namespace NCI.OCPL.Api.Glossary.Tests
             string expectedJsonValue = File.ReadAllText(TestingTools.GetPathToTestFile("TestData.json"));
             Assert.Equal(expectedJsonValue, actualJsonValue);
         }
-
-        [Fact]
-        public void Say_Hello_World()
-        {
-            Mock<ITermQueryService> termQueryService = new Mock<ITermQueryService>();
-            TermController controller = new TermController(termQueryService.Object);
-            string actualValue = controller.SayHelloWorld();
-            string expectedValue = "Hello New World";
-            Assert.Equal(expectedValue, actualValue);
-        }
-
-        [Fact]
-        public void Say_Hello_World_Error()
-        {
-            Mock<ITermQueryService> termQueryService = new Mock<ITermQueryService>();
-            TermController controller = new TermController(termQueryService.Object);
-            string actualValue = controller.SayHelloWorld();
-            string expectedValue = "Hello";
-            Assert.NotSame(expectedValue, actualValue);
-        }
     }
 }


### PR DESCRIPTION
(#19) Remove SayHelloWorld() method from TermController class.

Removed the SayHelloWorld() and its related test cases.

Closes #19 