### PR TITLE
(#44) Update API projects to .Net 2.1

### DIFF
--- a/src/NCI.OCPL.Api.Common.Testing/NCI.OCPL.Api.Common.Testing.csproj
+++ b/src/NCI.OCPL.Api.Common.Testing/NCI.OCPL.Api.Common.Testing.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -9,7 +9,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="NEST" Version="5.6.1" />
-    <PackageReference Include="Moq" Version="4.8.2" />
+    <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.2" />
   </ItemGroup>
 </Project>

--- a/src/NCI.OCPL.Api.Common/NCI.OCPL.Api.Common.csproj
+++ b/src/NCI.OCPL.Api.Common/NCI.OCPL.Api.Common.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <DebugType>portable</DebugType>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <AssetTargetFallback>$(PackageTargetFallback);dotnet5.6;portable-net45+win8</AssetTargetFallback>
@@ -11,6 +11,6 @@
     <PackageReference Include="System.Xml.XmlSerializer" Version="4.3.0" />
     <PackageReference Include="NEST" Version="5.6.1" />
     <PackageReference Include="NSwag.AspNetCore" Version="11.17.1" />
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.4" />
   </ItemGroup>
 </Project>

--- a/src/NCI.OCPL.Api.Glossary/NCI.OCPL.Api.Glossary.csproj
+++ b/src/NCI.OCPL.Api.Glossary/NCI.OCPL.Api.Glossary.csproj
@@ -7,13 +7,13 @@
   <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <Folder Include="wwwroot\" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.1"/>
+    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.4"/>
     <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.1.2" PrivateAssets="All" />
     <PackageReference Include="NSwag.AspNetCore" Version="11.17.1" />
     <PackageReference Include="NEST" Version="5.6.1" />
@@ -21,6 +21,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\NCI.OCPL.Api.Common\NCI.OCPL.Api.Common.csproj" />
-  </ItemGroup>  
+  </ItemGroup>
 
 </Project>

--- a/test/NCI.OCPL.Api.Glossary.Tests/NCI.OCPL.Api.Glossary.Tests.csproj
+++ b/test/NCI.OCPL.Api.Glossary.Tests/NCI.OCPL.Api.Glossary.Tests.csproj
@@ -14,14 +14,15 @@
 
   <ItemGroup>
     <None Include="TestData\TestData.json" CopyToOutputDirectory="Always" />
+    <None Include="TestData\TestData_SearchForTerms.json" CopyToOutputDirectory="Always" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9"/>
+    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.4" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
-    <PackageReference Include="Moq" Version="4.8.2" />
+    <PackageReference Include="Moq" Version="4.13.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- Target .Net Cor 2.1 across projects.
- Update Moq and AspNetCore versions.
- Update build-time list of data files to copy.

Closes #44 