### PR TITLE
Revert "Bump Microsoft.AspNetCore.App in /src/NCI.OCPL.Api.Glossary"

### DIFF
--- a/src/NCI.OCPL.Api.Common/NCI.OCPL.Api.Common.csproj
+++ b/src/NCI.OCPL.Api.Common/NCI.OCPL.Api.Common.csproj
@@ -11,6 +11,6 @@
     <PackageReference Include="System.Xml.XmlSerializer" Version="4.3.0" />
     <PackageReference Include="NEST" Version="5.6.1" />
     <PackageReference Include="NSwag.AspNetCore" Version="11.17.1" />
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.2.8" />
+    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.4" />
   </ItemGroup>
 </Project>

--- a/src/NCI.OCPL.Api.Glossary/NCI.OCPL.Api.Glossary.csproj
+++ b/src/NCI.OCPL.Api.Glossary/NCI.OCPL.Api.Glossary.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.2.8"/>
+    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.4"/>
     <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.1.2" PrivateAssets="All" />
     <PackageReference Include="NSwag.AspNetCore" Version="11.17.1" />
     <PackageReference Include="NEST" Version="5.6.1" />


### PR DESCRIPTION
This reverts commit 4f8598d1ed85711154314df9971bad6b194f5eb7.

IOW, don't trust the automated dependency checker.