### PR TITLE
(#55) Fix unit tests for ESTermQueryData.

### DIFF
--- a/test/NCI.OCPL.Api.Glossary.Tests/NCI.OCPL.Api.Glossary.Tests.csproj
+++ b/test/NCI.OCPL.Api.Glossary.Tests/NCI.OCPL.Api.Glossary.Tests.csproj
@@ -13,8 +13,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="TestData\TestData.json" CopyToOutputDirectory="Always" />
-    <None Include="TestData\TestData_SearchForTerms.json" CopyToOutputDirectory="Always" />
+    <None Include="TestData\*" CopyToOutputDirectory="Always" />
+    <None Include="TestData\ESTermQueryData\*" CopyToOutputDirectory="Always" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
ESTermQueryData/TermQuery.json was not marked for copying to output.

closes #55 