### PR TITLE
(#82) GetByID was not forming the id correctly

### DIFF
--- a/src/NCI.OCPL.Api.Glossary/Services/ESTermsQueryService.cs
+++ b/src/NCI.OCPL.Api.Glossary/Services/ESTermsQueryService.cs
@@ -57,7 +57,7 @@ namespace NCI.OCPL.Api.Glossary.Services
 
             try
             {
-                string idValue = id + "_" + dictionary + "_" + language + "_" + audience.ToString().ToLower();
+                string idValue = $"{id}_{dictionary?.ToLower()}_{language?.ToLower()}_{audience.ToString().ToLower()}";
                 response = await _elasticClient.GetAsync<GlossaryTerm>(new DocumentPath<GlossaryTerm>(idValue),
                         g => g.Index( this._apiOptions.AliasName ).Type("terms"));
 


### PR DESCRIPTION
- Lowercased Dictionary
- Lowercased Language
- Used a formatter for the ID

Closes #82 