### PR TITLE
(#43) Implement Terms/Count

### DIFF
--- a/src/NCI.OCPL.Api.Glossary/Controllers/TermsController.cs
+++ b/src/NCI.OCPL.Api.Glossary/Controllers/TermsController.cs
@@ -150,7 +150,22 @@ namespace NCI.OCPL.Api.Glossary.Controllers
 
             GlossaryTermResults res = await _termsQueryService.Expand(dictionary, audience, language, character, size, from, requestedFields);
             return res;
+        }
 
+        /// <summary>
+        /// Get the total number of terms available in the version of a dictionary matching a specific audience and language.
+        /// </summary>
+        /// <param name="dictionary">The specific dictionary to retrieve from.</param>
+        /// <param name="audience">The target audience.</param>
+        /// <param name="language">Language (English - en; Spanish - es).</param>
+        /// <returns>The number of terms available.</returns>
+        [HttpGet("count/{dictionary:required}/{audience:required}/{language:required}")]
+        public async Task<long> GetCount(string dictionary, AudienceType audience, string language)
+        {
+            if (String.IsNullOrWhiteSpace(dictionary) || String.IsNullOrWhiteSpace(language) || !Enum.IsDefined(typeof(AudienceType), audience))
+                throw new APIErrorException(400, "You must supply a valid dictionary, audience and language.");
+
+            return await _termsQueryService.GetCount(dictionary, audience, language);
         }
     }
 }

--- a/src/NCI.OCPL.Api.Glossary/Interfaces/ITermsQueryService.cs
+++ b/src/NCI.OCPL.Api.Glossary/Interfaces/ITermsQueryService.cs
@@ -58,5 +58,14 @@ namespace NCI.OCPL.Api.Glossary
         /// <returns>A GlossaryTermResults object containing the desired records.</returns>
         /// </summary>
         Task<GlossaryTermResults> Expand(string dictionary, AudienceType audience, string language, string expandCharacter, int size, int from, string[] requestedFields);
+
+        /// <summary>
+        /// Get the total number of terms available in the version of a dictionary matching a specific audience and language.
+        /// </summary>
+        /// <param name="dictionary">The specific dictionary to retrieve from.</param>
+        /// <param name="audience">The target audience.</param>
+        /// <param name="language">Language (English - en; Spanish - es).</param>
+        /// <returns>The number of terms available.</returns>
+        Task<long> GetCount(string dictionary, AudienceType audience, string language);
     }
 }

--- a/test/NCI.OCPL.Api.Glossary.Tests/TestData/ESTermsQueryData/GetCount/omg.json
+++ b/test/NCI.OCPL.Api.Glossary.Tests/TestData/ESTermsQueryData/GetCount/omg.json
@@ -1,0 +1,9 @@
+{
+    "count": 2147483647,
+    "_shards": {
+        "total": 1,
+        "successful": 1,
+        "skipped": 0,
+        "failed": 0
+    }
+}

--- a/test/NCI.OCPL.Api.Glossary.Tests/TestData/ESTermsQueryData/GetCount/one.json
+++ b/test/NCI.OCPL.Api.Glossary.Tests/TestData/ESTermsQueryData/GetCount/one.json
@@ -1,0 +1,9 @@
+{
+    "count": 1,
+    "_shards": {
+        "total": 1,
+        "successful": 1,
+        "skipped": 0,
+        "failed": 0
+    }
+}

--- a/test/NCI.OCPL.Api.Glossary.Tests/TestData/ESTermsQueryData/GetCount/realistic.json
+++ b/test/NCI.OCPL.Api.Glossary.Tests/TestData/ESTermsQueryData/GetCount/realistic.json
@@ -1,0 +1,9 @@
+{
+    "count": 8458,
+    "_shards": {
+        "total": 1,
+        "successful": 1,
+        "skipped": 0,
+        "failed": 0
+    }
+}

--- a/test/NCI.OCPL.Api.Glossary.Tests/TestData/ESTermsQueryData/GetCount/zero.json
+++ b/test/NCI.OCPL.Api.Glossary.Tests/TestData/ESTermsQueryData/GetCount/zero.json
@@ -1,0 +1,9 @@
+{
+    "count": 0,
+    "_shards": {
+        "total": 1,
+        "successful": 1,
+        "skipped": 0,
+        "failed": 0
+    }
+}

--- a/test/NCI.OCPL.Api.Glossary.Tests/Tests/Controllers/TermsController_Count_Test.cs
+++ b/test/NCI.OCPL.Api.Glossary.Tests/Tests/Controllers/TermsController_Count_Test.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Threading.Tasks;
+
+using Moq;
+using Xunit;
+
+using NCI.OCPL.Api.Common;
+using NCI.OCPL.Api.Glossary.Controllers;
+
+namespace NCI.OCPL.Api.Glossary.Tests
+{
+    public class TermsController_Count_Test
+    {
+        /// <summary>
+        /// Verify an error is thrown when no dictionary is specified.
+        /// </summary>
+        [Theory]
+        [InlineData(new object[] { null })]
+        [InlineData(new object[] { "" })]  // Empty string.
+        public async void Count_ErrorMessage_Dictionary(string dictionary)
+        {
+            Mock<ITermsQueryService> querySvc = new Mock<ITermsQueryService>();
+            TermsController controller = new TermsController(querySvc.Object);
+
+            APIErrorException ex = await Assert.ThrowsAsync<APIErrorException>(
+                () => controller.GetCount(dictionary, AudienceType.HealthProfessional, "en")
+            );
+            Assert.Equal(400, ex.HttpStatusCode);
+        }
+
+        /// <summary>
+        /// Verify an error is thrown when an invalid audience is specified.
+        /// </summary>
+        [Fact]
+        public async void Count_ErrorMessage_Audience()
+        {
+            Mock<ITermsQueryService> querySvc = new Mock<ITermsQueryService>();
+            TermsController controller = new TermsController(querySvc.Object);
+
+            APIErrorException ex = await Assert.ThrowsAsync<APIErrorException>(
+                () => controller.GetCount("Cancer.gov", (AudienceType)6, "en")
+            );
+            Assert.Equal(400, ex.HttpStatusCode);
+        }
+
+        /// <summary>
+        /// Verify an error is thrown when an no language is specified.
+        /// </summary>
+        [Theory]
+        [InlineData(new object[] { null })]
+        [InlineData(new object[] { "" })]  // Empty string.
+        public async void Count_ErrorMessage_Language(string badLanguage)
+        {
+            Mock<ITermsQueryService> querySvc = new Mock<ITermsQueryService>();
+            TermsController controller = new TermsController(querySvc.Object);
+
+            APIErrorException ex = await Assert.ThrowsAsync<APIErrorException>(
+                () => controller.GetCount("Cancer.gov", AudienceType.Patient, badLanguage)
+            );
+            Assert.Equal(400, ex.HttpStatusCode);
+        }
+
+        /// <summary>
+        /// Verify that controller arguments are passed to the query service as expected.
+        /// </summary>
+        [Theory]
+        [InlineData("Cancer.gov", AudienceType.HealthProfessional, "en")]
+        [InlineData("Cancer.gov", AudienceType.HealthProfessional, "es")]
+        [InlineData("Cancer.gov", AudienceType.Patient, "en")]
+        [InlineData("Cancer.gov", AudienceType.Patient, "es")]
+        [InlineData("Genetics", AudienceType.HealthProfessional, "en")]
+        [InlineData("Genetics", AudienceType.HealthProfessional, "es")]
+        [InlineData("Genetics", AudienceType.Patient, "en")]
+        [InlineData("Genetics", AudienceType.Patient, "es")]
+        public async void Count_QueryValues(string dictionary, AudienceType audience, string language)
+        {
+            Mock<ITermsQueryService> querySvc = new Mock<ITermsQueryService>();
+            TermsController controller = new TermsController(querySvc.Object);
+
+            // Set up the mock query service to handle the GetCount() call.
+            // The return value is unimportant for this test.
+            querySvc.Setup(
+                mock => mock.GetCount(
+                    It.IsAny<string>(),
+                    It.IsAny<AudienceType>(),
+                    It.IsAny<string>()
+                )
+            )
+            .Returns(Task.FromResult(default(long)));
+
+            long result = await controller.GetCount(dictionary, audience, language);
+
+            // Verify that the service layer is called:
+            //  a) with the expected values.
+            //  b) exactly once.
+            querySvc.Verify(
+                svc => svc.GetCount(dictionary, audience, language),
+                Times.Once
+            );
+        }
+
+        /// <summary>
+        /// Verify that the controller correctly returns the value from the query service.
+        /// </summary>
+        [Theory]
+        [InlineData(new object[] { 0 })]
+        [InlineData(new object[] { 3 })]
+        [InlineData(new object[] { 20 })]
+        [InlineData(new object[] { 100 })]
+        [InlineData(new object[] { 500 })]
+        [InlineData(new object[] { int.MaxValue })] // Utterly ridiculous.
+        public async void Count_QueryReturn(long returnCount)
+        {
+            Mock<ITermsQueryService> querySvc = new Mock<ITermsQueryService>();
+            TermsController controller = new TermsController(querySvc.Object);
+
+            // Set up the mock query service to handle the GetCount() call.
+            // The return value is unimportant for this test.
+            querySvc.Setup(
+                mock => mock.GetCount(
+                    It.IsAny<string>(),
+                    It.IsAny<AudienceType>(),
+                    It.IsAny<string>()
+                )
+            )
+            .Returns(Task.FromResult(returnCount));
+
+            // The arguments don't matter for this test.
+            long actual = await controller.GetCount("Cancer.gov", AudienceType.HealthProfessional, "es");
+            Assert.Equal(returnCount, actual);
+        }
+    }
+}

--- a/test/NCI.OCPL.Api.Glossary.Tests/Tests/Services/ESTermsQuery_CountTest.cs
+++ b/test/NCI.OCPL.Api.Glossary.Tests/Tests/Services/ESTermsQuery_CountTest.cs
@@ -1,0 +1,248 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+using Microsoft.Extensions.Logging.Testing;
+using Microsoft.Extensions.Options;
+
+using Elasticsearch.Net;
+using Moq;
+using Nest;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+using NCI.OCPL.Api.Common;
+using NCI.OCPL.Api.Common.Testing;
+using NCI.OCPL.Api.Glossary.Models;
+using NCI.OCPL.Api.Glossary.Services;
+using NCI.OCPL.Api.Glossary.Tests.ESTermsQueryTestData;
+
+namespace NCI.OCPL.Api.Glossary.Tests
+{
+    /// <summary>
+    /// Tests to verify that the requests for the term count
+    /// are put together in the expected manner.
+    /// </summary>
+    public class ESTermsQuery_CountTest
+    {
+        /// <summary>
+        /// Test data objects for use when validating how requests to Elasticsearch are assembled.
+        /// </summary>
+        public static IEnumerable<object[]> RequestData => new[]
+        {
+            new object[] {new Terms_GetCount_Request_CGov_HealthProfessional_English() },
+            new object[] {new Terms_GetCount_Request_CGov_HealthProfessional_Spanish() },
+            new object[] {new Terms_GetCount_Request_CGov_Patient_English() },
+            new object[] {new Terms_GetCount_Request_CGov_Patient_Spanish() },
+            new object[] {new Terms_GetCount_Request_Genetics_HealthProfessional_English() },
+            new object[] {new Terms_GetCount_Request_Genetics_HealthProfessional_Spanish() },
+            new object[] {new Terms_GetCount_Request_Genetics_Patient_English() },
+            new object[] {new Terms_GetCount_Request_Genetics_Patient_Spanish() }
+        };
+
+        /// <summary>
+        /// Test data objects for use when validating how Elasticsearch responses are handled.
+        /// </summary>
+        public static IEnumerable<object[]> ResponseData => new[]
+        {
+            new object[] { new Terms_GetCount_Response_Zero() },
+            new object[] { new Terms_GetCount_Response_One() },
+            new object[] { new Terms_GetCount_Response_Realistic() },
+            new object[] { new Terms_GetCount_Response_OMG() }
+        };
+
+        /// <summary>
+        /// Verify the ES request to get the count is put together correctly.
+        /// </summary>
+        /// <param name="data"></param>
+        [Theory, MemberData(nameof(RequestData))]
+        public async void GetCount_Request(BaseTermsQueryCountTestData data)
+        {
+            Uri esURI = null;
+            string esContentType = String.Empty;
+            HttpMethod esMethod = HttpMethod.DELETE; // Basically, something other than the expected value.
+
+            JObject requestBody = null;
+
+            ElasticsearchInterceptingConnection conn = new ElasticsearchInterceptingConnection();
+            conn.RegisterRequestHandlerForType<Nest.CountResponse>((req, res) =>
+            {
+                // We don't really care about the response for this test.
+                res.Stream = GetMockCountResponse();
+                res.StatusCode = 200;
+
+                esURI = req.Uri;
+                esContentType = req.ContentType;
+                esMethod = req.Method;
+                requestBody = conn.GetRequestPost(req);
+            });
+
+            // The URI does not matter, an InMemoryConnection never requests from the server.
+            var pool = new SingleNodeConnectionPool(new Uri("http://localhost:9200"));
+
+            var connectionSettings = new ConnectionSettings(pool, conn);
+            IElasticClient client = new ElasticClient(connectionSettings);
+
+            // Setup the mocked Options
+            IOptions<GlossaryAPIOptions> clientOptions = GetMockOptions();
+
+            ESTermsQueryService query = new ESTermsQueryService(client, clientOptions, new NullLogger<ESTermsQueryService>());
+
+            // We don't really care that this returns anything (for this test), only that the intercepting connection
+            // sets up the request correctly.
+            long result = await query.GetCount(data.DictionaryName, data.Audience, data.Language);
+
+            Assert.Equal("/glossaryv1/terms/_count", esURI.AbsolutePath);
+            Assert.Equal("application/json", esContentType);
+            Assert.Equal(HttpMethod.POST, esMethod);
+            Assert.Equal(data.ExpectedData, requestBody, new JTokenEqualityComparer());
+        }
+
+
+        /// <summary>
+        /// Verify the response from ES is processed correctly.
+        /// </summary>
+        [Theory, MemberData(nameof(ResponseData))]
+        public async void GetCount_Response(BaseTermsCountResponseData data)
+        {
+            Uri esURI = null;
+            string esContentType = String.Empty;
+            HttpMethod esMethod = HttpMethod.DELETE; // Basically, something other than the expected value.
+
+            JObject requestBody = null;
+
+            ElasticsearchInterceptingConnection conn = new ElasticsearchInterceptingConnection();
+            conn.RegisterRequestHandlerForType<Nest.CountResponse>((req, res) =>
+            {
+                res.Stream = TestingTools.GetTestFileAsStream("ESTermsQueryData/GetCount/" + data.TestFilename);
+                res.StatusCode = 200;
+
+                esURI = req.Uri;
+                esContentType = req.ContentType;
+                esMethod = req.Method;
+                requestBody = conn.GetRequestPost(req);
+            });
+
+            // The URI does not matter, an InMemoryConnection never requests from the server.
+            var pool = new SingleNodeConnectionPool(new Uri("http://localhost:9200"));
+
+            var connectionSettings = new ConnectionSettings(pool, conn);
+            IElasticClient client = new ElasticClient(connectionSettings);
+
+            // Setup the mocked Options
+            IOptions<GlossaryAPIOptions> clientOptions = GetMockOptions();
+
+            ESTermsQueryService query = new ESTermsQueryService(client, clientOptions, new NullLogger<ESTermsQueryService>());
+
+            // We don't really care about the inputs. What matters is the return, which is controlled by the mock ES connection.
+            long result = await query.GetCount("Cancer.gov", AudienceType.Patient, "es");
+
+            Assert.Equal(data.ExpectedCount, result);
+        }
+
+        /// <summary>
+        /// Verify that ESTermsQueryService responds correctly when Elasticsearch returns an error.
+        /// </summary>
+        [Fact]
+        public async void GetCount_ErrorResponse()
+        {
+            ElasticsearchInterceptingConnection conn = new ElasticsearchInterceptingConnection();
+            conn.RegisterRequestHandlerForType<Nest.CountResponse>((req, res) =>
+            {
+                res.Stream = null;
+                res.StatusCode = 200;
+            });
+
+            // The URI does not matter, an InMemoryConnection never requests from the server.
+            var pool = new SingleNodeConnectionPool(new Uri("http://localhost:9200"));
+
+            var connectionSettings = new ConnectionSettings(pool, conn);
+            IElasticClient client = new ElasticClient(connectionSettings);
+
+            // Setup the mocked Options
+            IOptions<GlossaryAPIOptions> clientOptions = GetMockOptions();
+
+            ESTermsQueryService query = new ESTermsQueryService(client, clientOptions, new NullLogger<ESTermsQueryService>());
+
+            // We don't care about the inputs, only in the error response.
+            APIErrorException ex = await Assert.ThrowsAsync<APIErrorException>(
+                () => query.GetCount("Cancer.gov", AudienceType.HealthProfessional, "es")
+            );
+            Assert.Equal(500, ex.HttpStatusCode);
+        }
+
+        /// <summary>
+        /// Verify that ESTermsQueryService responds correctly if Elasticsearch returns
+        /// a broken response.
+        /// </summary>
+        [Fact]
+        public async void GetCount_InvalidResponse()
+        {
+            ElasticsearchInterceptingConnection conn = new ElasticsearchInterceptingConnection();
+            conn.RegisterRequestHandlerForType<Nest.CountResponse>((req, res) =>
+            {
+                string partial =@"{
+                    ""count"": 8458,
+                    ""_shards"": {";
+                byte[] byteArray = Encoding.UTF8.GetBytes(partial);
+                res.Stream = new MemoryStream(byteArray);
+                res.StatusCode = 200;
+            });
+
+            // The URI does not matter, an InMemoryConnection never requests from the server.
+            var pool = new SingleNodeConnectionPool(new Uri("http://localhost:9200"));
+
+            var connectionSettings = new ConnectionSettings(pool, conn);
+            IElasticClient client = new ElasticClient(connectionSettings);
+
+            // Setup the mocked Options
+            IOptions<GlossaryAPIOptions> clientOptions = GetMockOptions();
+
+            ESTermsQueryService query = new ESTermsQueryService(client, clientOptions, new NullLogger<ESTermsQueryService>());
+
+            // We don't care about the inputs, only in the error response.
+            APIErrorException ex = await Assert.ThrowsAsync<APIErrorException>(
+                () => query.GetCount("Cancer.gov", AudienceType.HealthProfessional, "es")
+            );
+            Assert.Equal(500, ex.HttpStatusCode);
+        }
+
+        /// <summary>
+        /// Mock Elasticsearch configuraiton options.
+        /// </summary>
+        private IOptions<GlossaryAPIOptions> GetMockOptions()
+        {
+            Mock<IOptions<GlossaryAPIOptions>> clientOptions = new Mock<IOptions<GlossaryAPIOptions>>();
+            clientOptions
+                .SetupGet(opt => opt.Value)
+                .Returns(new GlossaryAPIOptions()
+                {
+                    AliasName = "glossaryv1"
+                }
+            );
+
+            return clientOptions.Object;
+        }
+
+        /// <summary>
+        /// Simulates a count response from Elasticsearch so we
+        /// have something for tests where we don't care about the response.
+        /// </summary>
+        private Stream GetMockCountResponse()
+        {
+            string empty = @"
+{
+    ""count"": 42,
+    ""_shards"": {
+                ""total"": 1,
+        ""successful"": 1,
+        ""skipped"": 0,
+        ""failed"": 0
+    }
+        }";
+            byte[] byteArray = Encoding.UTF8.GetBytes(empty);
+            return new MemoryStream(byteArray);
+        }
+    }
+}

--- a/test/NCI.OCPL.Api.Glossary.Tests/Tests/TestDataObjects/ESTermsQueryServiceTestObjects/GetCount/BaseTermsCountResponseData.cs
+++ b/test/NCI.OCPL.Api.Glossary.Tests/Tests/TestDataObjects/ESTermsQueryServiceTestObjects/GetCount/BaseTermsCountResponseData.cs
@@ -1,0 +1,17 @@
+using Newtonsoft.Json.Linq;
+
+namespace NCI.OCPL.Api.Glossary.Tests.ESTermsQueryTestData
+{
+    public abstract class BaseTermsCountResponseData
+    {
+        /// <summary>
+        /// Contains the name of the JSON data file to use in
+        /// </summary>
+        public abstract string TestFilename { get; }
+
+        /// <summary>
+        /// The expected result count.
+        /// </summary>
+        public abstract long ExpectedCount { get; }
+    }
+}

--- a/test/NCI.OCPL.Api.Glossary.Tests/Tests/TestDataObjects/ESTermsQueryServiceTestObjects/GetCount/BaseTermsQueryCountTestData.cs
+++ b/test/NCI.OCPL.Api.Glossary.Tests/Tests/TestDataObjects/ESTermsQueryServiceTestObjects/GetCount/BaseTermsQueryCountTestData.cs
@@ -1,0 +1,27 @@
+using Newtonsoft.Json.Linq;
+
+namespace NCI.OCPL.Api.Glossary.Tests.ESTermsQueryTestData
+{
+    public abstract class BaseTermsQueryCountTestData
+    {
+        /// <summary>
+        /// Gets the expected data object. This is what the request is supposed to look like.
+        /// </summary>
+        public abstract JObject ExpectedData { get; }
+
+        /// <summary>
+        /// The name of the dictionary for the suggestion request
+        /// </summary>
+        public abstract string DictionaryName { get; }
+
+        /// <summary>
+        /// The language of the suggestion request
+        /// </summary>
+        public abstract string Language { get; }
+
+        /// <summary>
+        /// The audience type for the suggestion request
+        /// </summary>
+        public abstract AudienceType Audience { get; }
+    }
+}

--- a/test/NCI.OCPL.Api.Glossary.Tests/Tests/TestDataObjects/ESTermsQueryServiceTestObjects/GetCount/Terms_GetCount_Request_CGov_HealthProfessional_English.cs
+++ b/test/NCI.OCPL.Api.Glossary.Tests/Tests/TestDataObjects/ESTermsQueryServiceTestObjects/GetCount/Terms_GetCount_Request_CGov_HealthProfessional_English.cs
@@ -1,0 +1,46 @@
+using Newtonsoft.Json.Linq;
+
+namespace NCI.OCPL.Api.Glossary.Tests.ESTermsQueryTestData
+{
+    public class Terms_GetCount_Request_CGov_HealthProfessional_English : BaseTermsQueryCountTestData
+    {
+        public override string DictionaryName => "Cancer.Gov";
+
+        public override string Language => "en";
+
+        public override AudienceType Audience => AudienceType.HealthProfessional;
+
+        public override JObject ExpectedData => JObject.Parse(@"
+{
+    ""query"": {
+        ""bool"": {
+            ""must"": [
+                {
+                    ""term"": {
+                        ""language"": {
+                            ""value"": ""en""
+                        }
+                    }
+                },
+                {
+                    ""term"": {
+                        ""audience"": {
+                            ""value"": ""HealthProfessional""
+                        }
+                    }
+                },
+                {
+                    ""term"": {
+                        ""dictionary"": {
+                            ""value"": ""Cancer.Gov""
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}
+        ");
+
+    }
+}

--- a/test/NCI.OCPL.Api.Glossary.Tests/Tests/TestDataObjects/ESTermsQueryServiceTestObjects/GetCount/Terms_GetCount_Request_CGov_HealthProfessional_Spanish.cs
+++ b/test/NCI.OCPL.Api.Glossary.Tests/Tests/TestDataObjects/ESTermsQueryServiceTestObjects/GetCount/Terms_GetCount_Request_CGov_HealthProfessional_Spanish.cs
@@ -1,0 +1,46 @@
+using Newtonsoft.Json.Linq;
+
+namespace NCI.OCPL.Api.Glossary.Tests.ESTermsQueryTestData
+{
+    public class Terms_GetCount_Request_CGov_HealthProfessional_Spanish : BaseTermsQueryCountTestData
+    {
+        public override string DictionaryName => "Cancer.Gov";
+
+        public override string Language => "es";
+
+        public override AudienceType Audience => AudienceType.HealthProfessional;
+
+        public override JObject ExpectedData => JObject.Parse(@"
+{
+    ""query"": {
+        ""bool"": {
+            ""must"": [
+                {
+                    ""term"": {
+                        ""language"": {
+                            ""value"": ""es""
+                        }
+                    }
+                },
+                {
+                    ""term"": {
+                        ""audience"": {
+                            ""value"": ""HealthProfessional""
+                        }
+                    }
+                },
+                {
+                    ""term"": {
+                        ""dictionary"": {
+                            ""value"": ""Cancer.Gov""
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}
+        ");
+
+    }
+}

--- a/test/NCI.OCPL.Api.Glossary.Tests/Tests/TestDataObjects/ESTermsQueryServiceTestObjects/GetCount/Terms_GetCount_Request_CGov_Patient_English.cs
+++ b/test/NCI.OCPL.Api.Glossary.Tests/Tests/TestDataObjects/ESTermsQueryServiceTestObjects/GetCount/Terms_GetCount_Request_CGov_Patient_English.cs
@@ -1,0 +1,46 @@
+using Newtonsoft.Json.Linq;
+
+namespace NCI.OCPL.Api.Glossary.Tests.ESTermsQueryTestData
+{
+    public class Terms_GetCount_Request_CGov_Patient_English : BaseTermsQueryCountTestData
+    {
+        public override string DictionaryName => "Cancer.Gov";
+
+        public override string Language => "en";
+
+        public override AudienceType Audience => AudienceType.Patient;
+
+        public override JObject ExpectedData => JObject.Parse(@"
+{
+    ""query"": {
+        ""bool"": {
+            ""must"": [
+                {
+                    ""term"": {
+                        ""language"": {
+                            ""value"": ""en""
+                        }
+                    }
+                },
+                {
+                    ""term"": {
+                        ""audience"": {
+                            ""value"": ""Patient""
+                        }
+                    }
+                },
+                {
+                    ""term"": {
+                        ""dictionary"": {
+                            ""value"": ""Cancer.Gov""
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}
+        ");
+
+    }
+}

--- a/test/NCI.OCPL.Api.Glossary.Tests/Tests/TestDataObjects/ESTermsQueryServiceTestObjects/GetCount/Terms_GetCount_Request_CGov_Patient_Spanish.cs
+++ b/test/NCI.OCPL.Api.Glossary.Tests/Tests/TestDataObjects/ESTermsQueryServiceTestObjects/GetCount/Terms_GetCount_Request_CGov_Patient_Spanish.cs
@@ -1,0 +1,46 @@
+using Newtonsoft.Json.Linq;
+
+namespace NCI.OCPL.Api.Glossary.Tests.ESTermsQueryTestData
+{
+    public class Terms_GetCount_Request_CGov_Patient_Spanish : BaseTermsQueryCountTestData
+    {
+        public override string DictionaryName => "Cancer.Gov";
+
+        public override string Language => "es";
+
+        public override AudienceType Audience => AudienceType.Patient;
+
+        public override JObject ExpectedData => JObject.Parse(@"
+{
+    ""query"": {
+        ""bool"": {
+            ""must"": [
+                {
+                    ""term"": {
+                        ""language"": {
+                            ""value"": ""es""
+                        }
+                    }
+                },
+                {
+                    ""term"": {
+                        ""audience"": {
+                            ""value"": ""Patient""
+                        }
+                    }
+                },
+                {
+                    ""term"": {
+                        ""dictionary"": {
+                            ""value"": ""Cancer.Gov""
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}
+        ");
+
+    }
+}

--- a/test/NCI.OCPL.Api.Glossary.Tests/Tests/TestDataObjects/ESTermsQueryServiceTestObjects/GetCount/Terms_GetCount_Request_Genetics_HealthProfessional_English.cs
+++ b/test/NCI.OCPL.Api.Glossary.Tests/Tests/TestDataObjects/ESTermsQueryServiceTestObjects/GetCount/Terms_GetCount_Request_Genetics_HealthProfessional_English.cs
@@ -1,0 +1,46 @@
+using Newtonsoft.Json.Linq;
+
+namespace NCI.OCPL.Api.Glossary.Tests.ESTermsQueryTestData
+{
+    public class Terms_GetCount_Request_Genetics_HealthProfessional_English : BaseTermsQueryCountTestData
+    {
+        public override string DictionaryName => "Genetics";
+
+        public override string Language => "en";
+
+        public override AudienceType Audience => AudienceType.HealthProfessional;
+
+        public override JObject ExpectedData => JObject.Parse(@"
+{
+    ""query"": {
+        ""bool"": {
+            ""must"": [
+                {
+                    ""term"": {
+                        ""language"": {
+                            ""value"": ""en""
+                        }
+                    }
+                },
+                {
+                    ""term"": {
+                        ""audience"": {
+                            ""value"": ""HealthProfessional""
+                        }
+                    }
+                },
+                {
+                    ""term"": {
+                        ""dictionary"": {
+                            ""value"": ""Genetics""
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}
+        ");
+
+    }
+}

--- a/test/NCI.OCPL.Api.Glossary.Tests/Tests/TestDataObjects/ESTermsQueryServiceTestObjects/GetCount/Terms_GetCount_Request_Genetics_HealthProfessional_Spanish.cs
+++ b/test/NCI.OCPL.Api.Glossary.Tests/Tests/TestDataObjects/ESTermsQueryServiceTestObjects/GetCount/Terms_GetCount_Request_Genetics_HealthProfessional_Spanish.cs
@@ -1,0 +1,46 @@
+using Newtonsoft.Json.Linq;
+
+namespace NCI.OCPL.Api.Glossary.Tests.ESTermsQueryTestData
+{
+    public class Terms_GetCount_Request_Genetics_HealthProfessional_Spanish : BaseTermsQueryCountTestData
+    {
+        public override string DictionaryName => "Genetics";
+
+        public override string Language => "es";
+
+        public override AudienceType Audience => AudienceType.HealthProfessional;
+
+        public override JObject ExpectedData => JObject.Parse(@"
+{
+    ""query"": {
+        ""bool"": {
+            ""must"": [
+                {
+                    ""term"": {
+                        ""language"": {
+                            ""value"": ""es""
+                        }
+                    }
+                },
+                {
+                    ""term"": {
+                        ""audience"": {
+                            ""value"": ""HealthProfessional""
+                        }
+                    }
+                },
+                {
+                    ""term"": {
+                        ""dictionary"": {
+                            ""value"": ""Genetics""
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}
+        ");
+
+    }
+}

--- a/test/NCI.OCPL.Api.Glossary.Tests/Tests/TestDataObjects/ESTermsQueryServiceTestObjects/GetCount/Terms_GetCount_Request_Genetics_Patient_English.cs
+++ b/test/NCI.OCPL.Api.Glossary.Tests/Tests/TestDataObjects/ESTermsQueryServiceTestObjects/GetCount/Terms_GetCount_Request_Genetics_Patient_English.cs
@@ -1,0 +1,46 @@
+using Newtonsoft.Json.Linq;
+
+namespace NCI.OCPL.Api.Glossary.Tests.ESTermsQueryTestData
+{
+    public class Terms_GetCount_Request_Genetics_Patient_English : BaseTermsQueryCountTestData
+    {
+        public override string DictionaryName => "Genetics";
+
+        public override string Language => "en";
+
+        public override AudienceType Audience => AudienceType.Patient;
+
+        public override JObject ExpectedData => JObject.Parse(@"
+{
+    ""query"": {
+        ""bool"": {
+            ""must"": [
+                {
+                    ""term"": {
+                        ""language"": {
+                            ""value"": ""en""
+                        }
+                    }
+                },
+                {
+                    ""term"": {
+                        ""audience"": {
+                            ""value"": ""Patient""
+                        }
+                    }
+                },
+                {
+                    ""term"": {
+                        ""dictionary"": {
+                            ""value"": ""Genetics""
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}
+        ");
+
+    }
+}

--- a/test/NCI.OCPL.Api.Glossary.Tests/Tests/TestDataObjects/ESTermsQueryServiceTestObjects/GetCount/Terms_GetCount_Request_Genetics_Patient_Spanish.cs
+++ b/test/NCI.OCPL.Api.Glossary.Tests/Tests/TestDataObjects/ESTermsQueryServiceTestObjects/GetCount/Terms_GetCount_Request_Genetics_Patient_Spanish.cs
@@ -1,0 +1,46 @@
+using Newtonsoft.Json.Linq;
+
+namespace NCI.OCPL.Api.Glossary.Tests.ESTermsQueryTestData
+{
+    public class Terms_GetCount_Request_Genetics_Patient_Spanish : BaseTermsQueryCountTestData
+    {
+        public override string DictionaryName => "Genetics";
+
+        public override string Language => "es";
+
+        public override AudienceType Audience => AudienceType.Patient;
+
+        public override JObject ExpectedData => JObject.Parse(@"
+{
+    ""query"": {
+        ""bool"": {
+            ""must"": [
+                {
+                    ""term"": {
+                        ""language"": {
+                            ""value"": ""es""
+                        }
+                    }
+                },
+                {
+                    ""term"": {
+                        ""audience"": {
+                            ""value"": ""Patient""
+                        }
+                    }
+                },
+                {
+                    ""term"": {
+                        ""dictionary"": {
+                            ""value"": ""Genetics""
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}
+        ");
+
+    }
+}

--- a/test/NCI.OCPL.Api.Glossary.Tests/Tests/TestDataObjects/ESTermsQueryServiceTestObjects/GetCount/Terms_GetCount_Response_OMG.cs
+++ b/test/NCI.OCPL.Api.Glossary.Tests/Tests/TestDataObjects/ESTermsQueryServiceTestObjects/GetCount/Terms_GetCount_Response_OMG.cs
@@ -1,0 +1,12 @@
+
+namespace NCI.OCPL.Api.Glossary.Tests.ESTermsQueryTestData
+{
+    // Just to be clear, ES should *never* return this many. If it ever does, something big is probably wrong. 😉
+    public class Terms_GetCount_Response_OMG : BaseTermsCountResponseData
+    {
+        public override string TestFilename => "omg.json";
+
+        public override long ExpectedCount => 2147483647;
+
+    }
+}

--- a/test/NCI.OCPL.Api.Glossary.Tests/Tests/TestDataObjects/ESTermsQueryServiceTestObjects/GetCount/Terms_GetCount_Response_One.cs
+++ b/test/NCI.OCPL.Api.Glossary.Tests/Tests/TestDataObjects/ESTermsQueryServiceTestObjects/GetCount/Terms_GetCount_Response_One.cs
@@ -1,0 +1,11 @@
+
+namespace NCI.OCPL.Api.Glossary.Tests.ESTermsQueryTestData
+{
+    public class Terms_GetCount_Response_One : BaseTermsCountResponseData
+    {
+        public override string TestFilename => "one.json";
+
+        public override long ExpectedCount => 1;
+
+    }
+}

--- a/test/NCI.OCPL.Api.Glossary.Tests/Tests/TestDataObjects/ESTermsQueryServiceTestObjects/GetCount/Terms_GetCount_Response_Realistic.cs
+++ b/test/NCI.OCPL.Api.Glossary.Tests/Tests/TestDataObjects/ESTermsQueryServiceTestObjects/GetCount/Terms_GetCount_Response_Realistic.cs
@@ -1,0 +1,11 @@
+
+namespace NCI.OCPL.Api.Glossary.Tests.ESTermsQueryTestData
+{
+    public class Terms_GetCount_Response_Realistic : BaseTermsCountResponseData
+    {
+        public override string TestFilename => "realistic.json";
+
+        public override long ExpectedCount => 8458;
+
+    }
+}

--- a/test/NCI.OCPL.Api.Glossary.Tests/Tests/TestDataObjects/ESTermsQueryServiceTestObjects/GetCount/Terms_GetCount_Response_Zero.cs
+++ b/test/NCI.OCPL.Api.Glossary.Tests/Tests/TestDataObjects/ESTermsQueryServiceTestObjects/GetCount/Terms_GetCount_Response_Zero.cs
@@ -1,0 +1,11 @@
+
+namespace NCI.OCPL.Api.Glossary.Tests.ESTermsQueryTestData
+{
+    public class Terms_GetCount_Response_Zero : BaseTermsCountResponseData
+    {
+        public override string TestFilename => "zero.json";
+
+        public override long ExpectedCount => 0;
+
+    }
+}


### PR DESCRIPTION
- Implement endpoint Terms/Count/<dictionary>/<audience>/<language>
- Implement TermsController::GetCount()
- Declare ITermsQueryService::GetCount()
- Define ESTermsQueryService::GetCount()
- Unit tests

Closes #43  