### PR TITLE
(#109) Log errors correctly

### DIFF
--- a/src/NCI.OCPL.Api.Glossary/Controllers/TermsController.cs
+++ b/src/NCI.OCPL.Api.Glossary/Controllers/TermsController.cs
@@ -91,13 +91,13 @@ namespace NCI.OCPL.Api.Glossary.Controllers
                     }
                     catch (Exception ex) {
                         // Swallow this Exception and move to the next combination.
-                        string msg = String.Format("Could not find fallback term with ID '{0}', dictionary '{1}', audience '{2}', and language '{3}'.", id, currentValue.Item1, currentValue.Item2, language);
-                        _logger.LogDebug(msg, ex);
+                        string msg = $"Could not find fallback term with ID '{id}', dictionary '{currentValue.Item1}', audience '{currentValue.Item2}', and language '{language}'.";
+                        _logger.LogDebug(ex, msg);
                     }
                     current = current.Next == null ? fallbackOptions.First : current.Next;
                 } while ( current != start );
 
-                string message = String.Format("Could not find fallback term with ID '{0}' for any combination of dictionary and audience.", id);
+                string message = $"Could not find fallback term with ID '{id}' for any combination of dictionary and audience.";
                 _logger.LogError(message);
                 throw new APIErrorException(500, message);
             }
@@ -143,14 +143,14 @@ namespace NCI.OCPL.Api.Glossary.Controllers
                     }
                     catch (Exception ex) {
                         // Swallow this Exception and move to the next combination.
-                        string msg = String.Format("Could not find fallback term with pretty URL name '{0}', dictionary '{1}', audience '{2}', and language '{3}'.", prettyUrlName, currentValue.Item1, currentValue.Item2, language);
-                        _logger.LogDebug(msg, ex);
+                        string msg = $"Could not find fallback term with pretty URL name '{prettyUrlName}', dictionary '{currentValue.Item1}', audience '{currentValue.Item2}', and language '{language}'.";
+                        _logger.LogDebug(ex, msg);
                     }
 
                     current = current.Next == null ? fallbackOptions.First : current.Next;
                 } while ( current != start );
 
-                string message = String.Format("Could not find fallback term with pretty URL name '{0}' for any combination of dictionary and audience.", prettyUrlName);
+                string message = $"Could not find fallback term with pretty URL name '{prettyUrlName}' for any combination of dictionary and audience.";
                 _logger.LogError(message);
                 throw new APIErrorException(500, message);
             }

--- a/src/NCI.OCPL.Api.Glossary/Services/ESAutosuggestQueryService.cs
+++ b/src/NCI.OCPL.Api.Glossary/Services/ESAutosuggestQueryService.cs
@@ -81,15 +81,15 @@ namespace NCI.OCPL.Api.Glossary.Services
             }
             catch (Exception ex)
             {
-                string msg = String.Format("Could not search dictionary '{0}', audience '{1}', and language '{2}'.", dictionary, audience, language);
-                _logger.LogError(msg, ex);
+                string msg = $"Could not search dictionary '{dictionary}', audience '{audience}', and language '{language}'.";
+                _logger.LogError($"Error searching index: '{this._apiOptions.AliasName}'.");
+                _logger.LogError(ex, msg);
                 throw new APIErrorException(500, msg);
             }
 
             if (!response.IsValid)
             {
-                String msg = String.Format("Invalid response when searching for dictionary '{0}', audience '{1}', language '{2}', query '{3}', contains '{4}', size '{5}'.", dictionary, audience, language, searchText, matchType, size);
-                _logger.LogError(msg);
+                _logger.LogError($"Invalid response when searching for dictionary '{dictionary}', audience '{audience}', language '{language}', query '{searchText}', contains '{matchType}', size '{size}'.");
                 throw new APIErrorException(500, "errors occured");
             }
 

--- a/src/NCI.OCPL.Api.Glossary/Services/ESTermsQueryService.cs
+++ b/src/NCI.OCPL.Api.Glossary/Services/ESTermsQueryService.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -66,21 +65,22 @@ namespace NCI.OCPL.Api.Glossary.Services
             }
             catch (Exception ex)
             {
-                String msg = String.Format("Could not search dictionary '{0}', audience '{1}', language '{2}' and id '{3}.", dictionary, audience, language, id);
-                _logger.LogError(msg, ex);
+                String msg = $"Could not search dictionary '{dictionary}', audience '{audience}', language '{language}' and id '{id}.";
+                _logger.LogError($"Error searching index: '{this._apiOptions.AliasName}'.");
+                _logger.LogError(ex, msg);
                 throw new APIErrorException(500, msg);
             }
 
             if (!response.IsValid)
             {
-                String msg = String.Format("Invalid response when searching for dictionary '{0}', audience '{1}', language '{2}' and id '{3}.", dictionary, audience, language, id);
+                String msg = $"Invalid response when searching for dictionary  '{dictionary}', audience '{audience}', language '{language}' and id '{id}.";
                 _logger.LogError(msg);
                 throw new APIErrorException(500, msg);
             }
 
             if(null==response.Source){
-                string msg = String.Format("Empty response when searching for dictionary '{0}', audience '{1}', language '{2}' and id '{3}.", dictionary, audience, language, id);
-                _logger.LogError(msg);
+                string msg = $"Empty response when searching for dictionary '{dictionary}', audience '{audience}', language '{language}' and id '{id}.";
+                _logger.LogDebug(msg);
                 throw new APIErrorException(200, msg);
             }
 
@@ -120,14 +120,15 @@ namespace NCI.OCPL.Api.Glossary.Services
             }
             catch (Exception ex)
             {
-                String msg = String.Format("Could not search dictionary '{0}', audience '{1}', language '{2}', pretty URL name '{3}'.", dictionary, audience, language, prettyUrlName);
-                _logger.LogError(msg, ex);
+                String msg = $"Could not search dictionary '{dictionary}', audience '{audience}', language '{language}', pretty URL name '{prettyUrlName}'.";
+                _logger.LogError($"Error searching index: '{this._apiOptions.AliasName}'.");
+                _logger.LogError(ex, msg);
                 throw new APIErrorException(500, msg);
             }
 
             if (!response.IsValid)
             {
-                String msg = String.Format("Invalid response when searching for dictionary '{0}', audience '{1}', language '{2}', pretty URL name '{3}'.", dictionary, audience, language, prettyUrlName);
+                String msg = $"Invalid response when searching for dictionary '{dictionary}', audience '{audience}', language '{language}', pretty URL name '{prettyUrlName}'.";
                 _logger.LogError(msg);
                 throw new APIErrorException(500, "errors occured");
             }
@@ -141,12 +142,12 @@ namespace NCI.OCPL.Api.Glossary.Services
             }
             else if (response.Total == 0)
             {
-                string msg = String.Format("Empty response when searching for dictionary '{0}', audience '{1}', language '{2}', pretty URL name '{3}'.", dictionary, audience, language, prettyUrlName);
-                _logger.LogError(msg);
+                string msg = $"Empty response when searching for dictionary '{dictionary}', audience '{audience}', language '{language}', pretty URL name '{prettyUrlName}'.";
+                _logger.LogDebug(msg);
                 throw new APIErrorException(200, msg);
             }
             else {
-                string msg = String.Format("Incorrect response when searching for dictionary '{0}', audience '{1}', language '{2}', pretty URL name '{3}'.", dictionary, audience, language, prettyUrlName);
+                string msg = $"Incorrect response when searching for dictionary '{dictionary}', audience '{audience}', language '{language}', pretty URL name '{prettyUrlName}'.";
                 _logger.LogError(msg);
                 throw new APIErrorException(200, msg);
             }
@@ -200,16 +201,15 @@ namespace NCI.OCPL.Api.Glossary.Services
             }
             catch (Exception ex)
             {
-                String msg = String.Format("Could not get dictionary '{0}', audience '{1}', language '{2}', size '{3}', from '{4}'.", dictionary, audience, language, size, from);
-                _logger.LogError("Error Fetching All from index: " + this._apiOptions.AliasName);
+                String msg = $"Could not get dictionary '{dictionary}', audience '{audience}', language '{language}', size '{size}', from '{from}'.";
+                _logger.LogError($"Error Fetching All from index: '{this._apiOptions.AliasName}'.");
                 _logger.LogError(ex, msg);
-
                 throw new APIErrorException(500, msg);
             }
 
             if (!response.IsValid)
             {
-                String msg = String.Format("Invalid response when getting dictionary '{0}', audience '{1}', language '{2}', size '{3}', from '{4}'.", dictionary, audience, language, size, from);
+                String msg = $"Invalid response when getting dictionary '{dictionary}', audience '{audience}', language '{language}', size '{size}', from '{from}'.";
                 _logger.LogError(msg);
                 throw new APIErrorException(500, "errors occured");
             }
@@ -299,14 +299,15 @@ namespace NCI.OCPL.Api.Glossary.Services
             }
             catch (Exception ex)
             {
-                String msg = String.Format("Could not search dictionary '{0}', audience '{1}', language '{2}', query '{3}', size '{4}', from '{5}'.", dictionary, audience, language, query, size, from);
+                String msg = $"Could not search dictionary '{dictionary}', audience '{audience}', language '{language}', query '{query}', size '{size}', from '{from}'.";
+                _logger.LogError($"Error searching index: '{this._apiOptions.AliasName}'.");
                 _logger.LogError(msg, ex);
                 throw new APIErrorException(500, msg);
             }
 
             if (!response.IsValid)
             {
-                String msg = String.Format("Invalid response when searching for dictionary '{0}', audience '{1}', language '{2}', query '{3}', size '{4}', from '{5}'.", dictionary, audience, language, query, size, from);
+                String msg = $"Invalid response when searching for dictionary '{dictionary}', audience '{audience}', language '{language}', query '{query}', size '{size}', from '{from}'.";
                 _logger.LogError(msg);
                 throw new APIErrorException(500, "errors occured");
             }
@@ -394,14 +395,15 @@ namespace NCI.OCPL.Api.Glossary.Services
             }
             catch (Exception ex)
             {
-                String msg = String.Format("Could not search dictionary '{0}', audience '{1}', language '{2}', character '{3}', size '{4}', from '{5}'.", dictionary, audience, language, expandCharacter, size, from);
+                String msg = $"Could not search dictionary '{dictionary}', audience '{audience}', language '{language}', character '{expandCharacter}', size '{size}', from '{from}'.";
+                _logger.LogError($"Error searching index: '{this._apiOptions.AliasName}'.");
                 _logger.LogError(msg, ex);
                 throw new APIErrorException(500, msg);
             }
 
             if (!response.IsValid)
             {
-                String msg = String.Format("Invalid response when searching for dictionary '{0}', audience '{1}', language '{2}', character '{3}', size '{4}', from '{5}'.", dictionary, audience, language, expandCharacter, size, from);
+                String msg = $"Invalid response when searching for '{dictionary}', audience '{audience}', language '{language}', character '{expandCharacter}', size '{size}', from '{from}'.";
                 _logger.LogError(msg);
                 throw new APIErrorException(500, "errors occured");
             }
@@ -521,6 +523,7 @@ namespace NCI.OCPL.Api.Glossary.Services
             catch (Exception ex)
             {
                 String msg = $"Could not get a count for dictionary '{dictionary}', audience '{audience}', language '{language}'";
+                _logger.LogError($"Error getting count on index: '{this._apiOptions.AliasName}'.");
                 _logger.LogError(msg, ex);
                 throw new APIErrorException(500, msg);
             }


### PR DESCRIPTION
- Specify exception in the correct location in the LogError call when logging an exception.
- Replace String.Format calls with inline interpolation.
- Switch to LogDebug when logging normal no result.

Close #109