### PR TITLE
(#110) Apply uniform HTTP status codes.

### DIFF
--- a/src/NCI.OCPL.Api.Glossary/Controllers/AutosuggestController.cs
+++ b/src/NCI.OCPL.Api.Glossary/Controllers/AutosuggestController.cs
@@ -50,7 +50,7 @@ namespace NCI.OCPL.Api.Glossary.Controllers
                 throw new APIErrorException(400, "The `matchType` parameter must be either 'Begins' or 'Contains'.");
 
             if (language.ToLower() != "en" && language.ToLower() != "es")
-                throw new APIErrorException(404, "Unsupported Language. Valid values are 'en' and 'es'.");
+                throw new APIErrorException(400, "Unsupported Language. Valid values are 'en' and 'es'.");
 
             if (size <= 0)
                 size = 20;

--- a/src/NCI.OCPL.Api.Glossary/Controllers/TermsController.cs
+++ b/src/NCI.OCPL.Api.Glossary/Controllers/TermsController.cs
@@ -68,7 +68,7 @@ namespace NCI.OCPL.Api.Glossary.Controllers
             }
 
             if (language.ToLower() != "en" && language.ToLower() != "es")
-                throw new APIErrorException(404, "Unsupported Language. Please try either 'en' or 'es'");
+                throw new APIErrorException(400, "Unsupported Language. Please try either 'en' or 'es'");
 
             if (useFallback == false) {
                 return await _termsQueryService.GetById(dictionary, audience, language, id);
@@ -99,7 +99,7 @@ namespace NCI.OCPL.Api.Glossary.Controllers
 
                 string message = $"Could not find fallback term with ID '{id}' for any combination of dictionary and audience.";
                 _logger.LogError(message);
-                throw new APIErrorException(500, message);
+                throw new APIErrorException(404, message);
             }
         }
 
@@ -116,10 +116,10 @@ namespace NCI.OCPL.Api.Glossary.Controllers
             }
 
             if (language.ToLower() != "en" && language.ToLower() != "es")
-                throw new APIErrorException(404, "Unsupported Language. Please try either 'en' or 'es'");
+                throw new APIErrorException(400, "Unsupported Language. Please try either 'en' or 'es'");
 
             if (String.IsNullOrWhiteSpace(prettyUrlName))
-                throw new APIErrorException(404, "You must specify the prettyUrlName parameter.");
+                throw new APIErrorException(400, "You must specify the prettyUrlName parameter.");
 
             // Call GetByName with specified parameters.
             if (useFallback == false) {
@@ -152,7 +152,7 @@ namespace NCI.OCPL.Api.Glossary.Controllers
 
                 string message = $"Could not find fallback term with pretty URL name '{prettyUrlName}' for any combination of dictionary and audience.";
                 _logger.LogError(message);
-                throw new APIErrorException(500, message);
+                throw new APIErrorException(404, message);
             }
         }
 
@@ -173,7 +173,7 @@ namespace NCI.OCPL.Api.Glossary.Controllers
                 throw new APIErrorException(400, "You must supply a valid dictionary, audience and language.");
 
             if (language.ToLower() != "en" && language.ToLower() != "es")
-                throw new APIErrorException(404, "Unsupported Language. Valid values are 'en' and 'es'.");
+                throw new APIErrorException(400, "Unsupported Language. Valid values are 'en' and 'es'.");
 
             if (size <= 0)
                 size = 100;
@@ -210,7 +210,7 @@ namespace NCI.OCPL.Api.Glossary.Controllers
                 throw new APIErrorException(400, "You must supply a valid dictionary, audience and language.");
 
             if (language.ToLower() != "en" && language.ToLower() != "es")
-                throw new APIErrorException(404, "Unsupported Language. Valid values are 'en' and 'es'.");
+                throw new APIErrorException(400, "Unsupported Language. Valid values are 'en' and 'es'.");
 
             if (!Enum.IsDefined(typeof(MatchType), matchType))
                 throw new APIErrorException(400, "The `matchType` parameter must be either 'Begins' or 'Contains'.");
@@ -248,7 +248,7 @@ namespace NCI.OCPL.Api.Glossary.Controllers
                 throw new APIErrorException(400, "You must supply a valid dictionary, audience and language");
 
             if (language.ToLower() != "en" && language.ToLower() != "es")
-                throw new APIErrorException(404, "Unsupported Language. Please try either 'en' or 'es'");
+                throw new APIErrorException(400, "Unsupported Language. Please try either 'en' or 'es'");
 
             if (size <= 0)
                 size = 100;

--- a/src/NCI.OCPL.Api.Glossary/Services/ESTermsQueryService.cs
+++ b/src/NCI.OCPL.Api.Glossary/Services/ESTermsQueryService.cs
@@ -79,9 +79,9 @@ namespace NCI.OCPL.Api.Glossary.Services
             }
 
             if(null==response.Source){
-                string msg = $"Empty response when searching for dictionary '{dictionary}', audience '{audience}', language '{language}' and id '{id}.";
+                string msg = $"No match for dictionary '{dictionary}', audience '{audience}', language '{language}' and id '{id}.";
                 _logger.LogDebug(msg);
-                throw new APIErrorException(200, msg);
+                throw new APIErrorException(404, msg);
             }
 
             return response.Source;
@@ -142,14 +142,14 @@ namespace NCI.OCPL.Api.Glossary.Services
             }
             else if (response.Total == 0)
             {
-                string msg = $"Empty response when searching for dictionary '{dictionary}', audience '{audience}', language '{language}', pretty URL name '{prettyUrlName}'.";
+                string msg = $"No match for dictionary '{dictionary}', audience '{audience}', language '{language}', pretty URL name '{prettyUrlName}'.";
                 _logger.LogDebug(msg);
-                throw new APIErrorException(200, msg);
+                throw new APIErrorException(404, msg);
             }
             else {
                 string msg = $"Incorrect response when searching for dictionary '{dictionary}', audience '{audience}', language '{language}', pretty URL name '{prettyUrlName}'.";
                 _logger.LogError(msg);
-                throw new APIErrorException(200, msg);
+                throw new APIErrorException(500, "Errors have occured.");
             }
 
             return glossaryTerm;

--- a/test/NCI.OCPL.Api.Glossary.Tests/Tests/Services/ESTermsQueryServiceTest.GetByName.cs
+++ b/test/NCI.OCPL.Api.Glossary.Tests/Tests/Services/ESTermsQueryServiceTest.GetByName.cs
@@ -168,9 +168,9 @@ namespace NCI.OCPL.Api.Glossary.Tests
         /// Test that GetByName throws correct error for no results.
         /// </summary>
         [Theory]
-        [InlineData("getbyname_noresults", "Empty response when searching for dictionary 'Cancer.gov', audience 'Patient', language 'en', pretty URL name 's-1'.")]
-        [InlineData("getbyname_multiplehits", "Incorrect response when searching for dictionary 'Cancer.gov', audience 'Patient', language 'en', pretty URL name 's-1'.")]
-        public async void GetByName_TestNoOrIncorrectResults(string file, string message)
+        [InlineData("getbyname_noresults", 404, "No match for dictionary 'Cancer.gov', audience 'Patient', language 'en', pretty URL name 's-1'.")]
+        [InlineData("getbyname_multiplehits", 500, "Errors have occured.")]
+        public async void GetByName_TestNoOrIncorrectResults(string file, int expectedStatusCode, string expectedMessage)
         {
             IElasticClient client = GetByName_GetElasticClientWithData(file);
 
@@ -180,8 +180,8 @@ namespace NCI.OCPL.Api.Glossary.Tests
             ESTermsQueryService termsClient = new ESTermsQueryService(client, gTermsClientOptions, new NullLogger<ESTermsQueryService>());
 
             APIErrorException ex = await Assert.ThrowsAsync<APIErrorException>(() => termsClient.GetByName("Cancer.gov", AudienceType.Patient, "en", "s-1"));
-            Assert.Equal(200, ex.HttpStatusCode);
-            Assert.Equal(ex.Message, message);
+            Assert.Equal(expectedStatusCode, ex.HttpStatusCode);
+            Assert.Equal(expectedMessage, ex.Message);
         }
 
         /// <summary>


### PR DESCRIPTION
- 400 - invalid parameters.
- 404 - no result found.
- 500 - unexpected server behavior (Elasticsearch result).
- Update status messages to reflect new status codes.
- Update tests to verify updated status code and messages.

Close #110 