### PR TITLE
(#141) Remove set-env command from integration tests.

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -189,7 +189,7 @@ jobs:
               ## Store the exit code off so we can pass this step and
               ## capture the test output in the next step, but still
               ## fail the entire job
-              echo ::set-env name=TEST_EXIT_CODE::$?
+              echo "TEST_EXIT_CODE=$?" >> $GITHUB_ENV
               exit 0
       - name: Upload Integration test results
         uses: actions/upload-artifact@v1


### PR DESCRIPTION
Pass TEST_EXIT_CODE value between steps via environment file.

Closes #141 