### PR TITLE
(#143) Fix title- vs. lower-case in fallback logic

### DIFF
--- a/integration-tests/data/source/glossary-es-mapping.json
+++ b/integration-tests/data/source/glossary-es-mapping.json
@@ -17,7 +17,8 @@
                     }
                 },
                 "dictionary": {
-                    "type": "keyword"
+                    "type": "keyword",
+                    "normalizer": "caseinsensitive_normalizer"
                 },
                 "first_letter": {
                     "type": "keyword",

--- a/integration-tests/features/getById.feature
+++ b/integration-tests/features/getById.feature
@@ -1,9 +1,0 @@
-Feature: Get glossary term by ID
-
-  Background:
-    * url apiHost
-
-  Scenario: get a glossary term by its ID
-    Given path 'Terms', 'Cancer.gov', 'Patient', 'en',
-    When method get
-    Then status 200

--- a/integration-tests/features/terms/getById/error-fallback-unknown-dictionary-hp-en-43966.json
+++ b/integration-tests/features/terms/getById/error-fallback-unknown-dictionary-hp-en-43966.json
@@ -1,0 +1,3 @@
+{
+    "Message": "Could not find initial fallback combination with dictionary 'unknown' and audience 'HealthProfessional'."
+}

--- a/integration-tests/features/terms/getById/error-fallback-unknown-dictionary-patient-en-43966.json
+++ b/integration-tests/features/terms/getById/error-fallback-unknown-dictionary-patient-en-43966.json
@@ -1,0 +1,3 @@
+{
+    "Message": "Could not find initial fallback combination with dictionary 'unknown' and audience 'Patient'."
+}

--- a/integration-tests/features/terms/getById/errorFallback.feature
+++ b/integration-tests/features/terms/getById/errorFallback.feature
@@ -1,0 +1,18 @@
+Feature: GetById with useFallback=true with expected errors.
+
+    Background:
+        * url apiHost
+
+    Scenario Outline: Given the dictionary, audience, language, id, and useFallback = true,
+        validate the error thrown.
+
+        Given path 'Terms', dictionary, audience, language, id
+        And param useFallback = true
+        When method get
+        Then status 404
+        And match response == read( expected )
+
+        Examples:
+            | dictionary | audience             | language | id       | expected                                                  |
+            | Unknown    | Patient              | en       | 43966    | error-fallback-unknown-dictionary-patient-en-43966.json   |
+            | Unknown    | HealthProfessional   | en       | 43966    | error-fallback-unknown-dictionary-hp-en-43966.json        |

--- a/integration-tests/features/terms/getById/success-fallback-lower-case-cancergov-hp-en-556486.json
+++ b/integration-tests/features/terms/getById/success-fallback-lower-case-cancergov-hp-en-556486.json
@@ -1,0 +1,26 @@
+{
+    "termId": 556486,
+    "language": "en",
+    "dictionary": "Genetics",
+    "audience": "HealthProfessional",
+    "termName": "deleterious mutation",
+    "firstLetter": "d",
+    "prettyUrlName": "deleterious-mutation",
+    "pronunciation": {
+        "key": "(DEH-leh-TEER-ee-us myoo-TAY-shun)",
+        "audio": "https://nci-media-dev.cancer.gov/pdq/media/audio/736913.mp3"
+    },
+    "definition": {
+        "text": "A genetic alteration that increases an individual\u2019s susceptibility or predisposition to a certain disease or disorder. When such a variant (or mutation) is inherited, development of symptoms is more likely, but not certain.  Also called disease-causing mutation, pathogenic variant, predisposing mutation, and susceptibility gene mutation.",
+        "html": "A genetic alteration that increases an individual\u2019s susceptibility or predisposition to a certain disease or disorder. When such a variant (or mutation) is inherited, development of symptoms is more likely, but not certain.  Also called disease-causing mutation, pathogenic variant, predisposing mutation, and susceptibility gene mutation."
+    },
+    "otherLanguages": [
+        {
+            "language": "es",
+            "termName": "mutaci\u00f3n delet\u00e9rea",
+            "prettyUrlName": "mutacion-deleterea"
+        }
+    ],
+    "media": [],
+    "relatedResources": []
+}

--- a/integration-tests/features/terms/getById/success-fallback-lower-case-cancergov-hp-es-556486.json
+++ b/integration-tests/features/terms/getById/success-fallback-lower-case-cancergov-hp-es-556486.json
@@ -1,0 +1,23 @@
+{
+    "termId": 556486,
+    "language": "es",
+    "dictionary": "Genetics",
+    "audience": "HealthProfessional",
+    "termName": "mutaci\u00f3n delet\u00e9rea",
+    "firstLetter": "m",
+    "prettyUrlName": "mutacion-deleterea",
+    "pronunciation": null,
+    "definition": {
+        "text": "Alteraci\u00f3n gen\u00e9tica que aumenta la susceptibilidad o predisposici\u00f3n de la persona a padecer  ciertas enfermedades o trastornos. Cuando se hereda esta variante o mutaci\u00f3n, es m\u00e1s probable que se presenten s\u00edntomas, aunque esto no es seguro. Tambi\u00e9n se llama mutaci\u00f3n causal de enfermedad, mutaci\u00f3n en gen de susceptibilidad, mutaci\u00f3n predisponente y variante pat\u00f3gena.",
+        "html": "Alteraci\u00f3n gen\u00e9tica que aumenta la susceptibilidad o predisposici\u00f3n de la persona a padecer  ciertas enfermedades o trastornos. Cuando se hereda esta variante o mutaci\u00f3n, es m\u00e1s probable que se presenten s\u00edntomas, aunque esto no es seguro. Tambi\u00e9n se llama mutaci\u00f3n causal de enfermedad, mutaci\u00f3n en gen de susceptibilidad, mutaci\u00f3n predisponente y variante pat\u00f3gena."
+    },
+    "otherLanguages": [
+        {
+            "language": "en",
+            "termName": "deleterious mutation",
+            "prettyUrlName": "deleterious-mutation"
+        }
+    ],
+    "media": [],
+    "relatedResources": []
+}

--- a/integration-tests/features/terms/getById/success-fallback-lower-case-cancergov-patient-en-43980.json
+++ b/integration-tests/features/terms/getById/success-fallback-lower-case-cancergov-patient-en-43980.json
@@ -1,0 +1,26 @@
+{
+    "termId": 43980,
+    "language": "en",
+    "dictionary": "Cancer.gov",
+    "audience": "Patient",
+    "termName": "postoperative",
+    "firstLetter": "p",
+    "prettyUrlName": "postoperative",
+    "pronunciation": {
+        "key": "(post-AH-pruh-tiv)",
+        "audio": "https://nci-media-dev.cancer.gov/pdq/media/audio/727653.mp3"
+    },
+    "definition": {
+        "text": "After surgery.",
+        "html": "After surgery."
+    },
+    "otherLanguages": [
+        {
+            "language": "es",
+            "termName": "posoperatorio",
+            "prettyUrlName": "posoperatorio"
+        }
+    ],
+    "media": [],
+    "relatedResources": []
+}

--- a/integration-tests/features/terms/getById/success-fallback-lower-case-cancergov-patient-es-43980.json
+++ b/integration-tests/features/terms/getById/success-fallback-lower-case-cancergov-patient-es-43980.json
@@ -1,0 +1,26 @@
+{
+    "termId": 43980,
+    "language": "es",
+    "dictionary": "Cancer.gov",
+    "audience": "Patient",
+    "termName": "posoperatorio",
+    "firstLetter": "p",
+    "prettyUrlName": "posoperatorio",
+    "pronunciation": {
+        "key": null,
+        "audio": "https://nci-media-dev.cancer.gov/pdq/media/audio/727654.mp3"
+    },
+    "definition": {
+        "text": "Despu\u00e9s de una cirug\u00eda.",
+        "html": "Despu\u00e9s de una cirug\u00eda."
+    },
+    "otherLanguages": [
+        {
+            "language": "en",
+            "termName": "postoperative",
+            "prettyUrlName": "postoperative"
+        }
+    ],
+    "media": [],
+    "relatedResources": []
+}

--- a/integration-tests/features/terms/getById/success-fallback-lower-case-genetics-hp-en-43969.json
+++ b/integration-tests/features/terms/getById/success-fallback-lower-case-genetics-hp-en-43969.json
@@ -1,0 +1,26 @@
+{
+    "termId": 43969,
+    "language": "en",
+    "dictionary": "Cancer.gov",
+    "audience": "Patient",
+    "termName": "arteriogram",
+    "firstLetter": "a",
+    "prettyUrlName": "arteriogram",
+    "pronunciation": {
+        "key": "(ar-TEER-ee-oh-gram)",
+        "audio": "https://nci-media-dev.cancer.gov/pdq/media/audio/703964.mp3"
+    },
+    "definition": {
+        "text": "An x-ray of arteries. The person receives an injection of a dye that outlines the vessels on the x-ray.",
+        "html": "An x-ray of arteries. The person receives an injection of a dye that outlines the vessels on the x-ray."
+    },
+    "otherLanguages": [
+        {
+            "language": "es",
+            "termName": "arteriograma",
+            "prettyUrlName": "arteriograma"
+        }
+    ],
+    "media": [],
+    "relatedResources": []
+}

--- a/integration-tests/features/terms/getById/success-fallback-lower-case-genetics-hp-en-44805.json
+++ b/integration-tests/features/terms/getById/success-fallback-lower-case-genetics-hp-en-44805.json
@@ -1,0 +1,32 @@
+{
+    "termId": 44805,
+    "language": "en",
+    "dictionary": "Genetics",
+    "audience": "HealthProfessional",
+    "termName": "polymorphism",
+    "firstLetter": "p",
+    "prettyUrlName": "polymorphism",
+    "pronunciation": {
+        "key": "(PAH-lee-MOR-fih-zum)",
+        "audio": "https://nci-media-dev.cancer.gov/pdq/media/audio/705993.mp3"
+    },
+    "definition": {
+        "text": "A common variant in a specific sequence of DNA. \u201cCommon\u201d is typically defined as an allele frequency of at least 1% in the general population.",
+        "html": "A common variant in a specific sequence of DNA. \u201cCommon\u201d is typically defined as an allele frequency of at least 1% in the general population."
+    },
+    "relatedResources": [
+        {
+            "Type": "External",
+            "Text": "Polymorphism",
+            "Url": "https://www.genome.gov/genetics-glossary/Polymorphism"
+        }
+    ],
+    "otherLanguages": [
+        {
+            "language": "es",
+            "termName": "polimorfismo",
+            "prettyUrlName": "polimorfismo"
+        }
+    ],
+    "media": []
+}

--- a/integration-tests/features/terms/getById/success-fallback-lower-case-genetics-hp-es-43969.json
+++ b/integration-tests/features/terms/getById/success-fallback-lower-case-genetics-hp-es-43969.json
@@ -1,0 +1,26 @@
+{
+    "termId": 43969,
+    "language": "es",
+    "dictionary": "Cancer.gov",
+    "audience": "Patient",
+    "termName": "arteriograma",
+    "firstLetter": "a",
+    "prettyUrlName":"arteriograma",
+    "pronunciation": {
+        "key": null,
+        "audio": "https://nci-media-dev.cancer.gov/pdq/media/audio/703965.mp3"
+    },
+    "definition": {
+        "text": "Radiograf\u00eda de las arterias. La persona recibe una inyecci\u00f3n con un tinte que hace resaltar los vasos en la radiograf\u00eda.",
+        "html": "Radiograf\u00eda de las arterias. La persona recibe una inyecci\u00f3n con un tinte que hace resaltar los vasos en la radiograf\u00eda."
+    },
+    "otherLanguages": [
+        {
+            "language": "en",
+            "termName": "arteriogram",
+            "prettyUrlName": "arteriogram"
+        }
+    ],
+    "media": [],
+    "relatedResources": []
+}

--- a/integration-tests/features/terms/getById/success-fallback-lower-case-genetics-hp-es-44805.json
+++ b/integration-tests/features/terms/getById/success-fallback-lower-case-genetics-hp-es-44805.json
@@ -1,0 +1,32 @@
+{
+    "termId": 44805,
+    "language": "es",
+    "dictionary": "Genetics",
+    "audience": "HealthProfessional",
+    "termName": "polimorfismo",
+    "firstLetter": "p",
+    "prettyUrlName": "polimorfismo",
+    "pronunciation": {
+        "key": null,
+        "audio": "https://nci-media-dev.cancer.gov/pdq/media/audio/705994.mp3"
+    },
+    "definition": {
+        "text": "Variante com\u00fan en una secuencia espec\u00edfica de ADN. Normalmente el t\u00e9rmino \u201ccom\u00fan\u201d se define por una frecuencia al\u00e9lica de al menos 1\u00a0% en la poblaci\u00f3n general.",
+        "html": "Variante com\u00fan en una secuencia espec\u00edfica de ADN. Normalmente el t\u00e9rmino \u201ccom\u00fan\u201d se define por una frecuencia al\u00e9lica de al menos 1\u00a0% en la poblaci\u00f3n general."
+    },
+    "relatedResources": [
+        {
+            "Type": "External",
+            "Text": "Polimorfismo",
+            "Url": "https://www.genome.gov/es/genetics-glossary/Polimorfismo"
+        }
+    ],
+    "otherLanguages": [
+        {
+            "language": "en",
+            "termName": "polymorphism",
+            "prettyUrlName": "polymorphism"
+        }
+    ],
+    "media": []
+}

--- a/integration-tests/features/terms/getById/success-fallback-title-case-cancergov-hp-en-556486.json
+++ b/integration-tests/features/terms/getById/success-fallback-title-case-cancergov-hp-en-556486.json
@@ -1,0 +1,27 @@
+{
+    "termId": 556486,
+    "language": "en",
+    "dictionary": "Genetics",
+    "audience": "HealthProfessional",
+    "termName": "deleterious mutation",
+    "firstLetter": "d",
+    "prettyUrlName": "deleterious-mutation",
+    "pronunciation": {
+        "key": "(DEH-leh-TEER-ee-us myoo-TAY-shun)",
+        "audio": "https://nci-media-dev.cancer.gov/pdq/media/audio/736913.mp3"
+    },
+    "definition": {
+        "text": "A genetic alteration that increases an individual\u2019s susceptibility or predisposition to a certain disease or disorder. When such a variant (or mutation) is inherited, development of symptoms is more likely, but not certain.  Also called disease-causing mutation, pathogenic variant, predisposing mutation, and susceptibility gene mutation.",
+        "html": "A genetic alteration that increases an individual\u2019s susceptibility or predisposition to a certain disease or disorder. When such a variant (or mutation) is inherited, development of symptoms is more likely, but not certain.  Also called disease-causing mutation, pathogenic variant, predisposing mutation, and susceptibility gene mutation."
+    },
+    "otherLanguages": [
+        {
+            "language": "es",
+            "termName": "mutaci\u00f3n delet\u00e9rea",
+            "prettyUrlName": "mutacion-deleterea"
+        }
+    ]
+    ,
+    "media": [],
+    "relatedResources": []
+}

--- a/integration-tests/features/terms/getById/success-fallback-title-case-cancergov-hp-es-556486.json
+++ b/integration-tests/features/terms/getById/success-fallback-title-case-cancergov-hp-es-556486.json
@@ -1,0 +1,23 @@
+{
+    "termId": 556486,
+    "language": "es",
+    "dictionary": "Genetics",
+    "audience": "HealthProfessional",
+    "termName": "mutaci\u00f3n delet\u00e9rea",
+    "firstLetter": "m",
+    "prettyUrlName": "mutacion-deleterea",
+    "pronunciation": null,
+    "definition": {
+        "text": "Alteraci\u00f3n gen\u00e9tica que aumenta la susceptibilidad o predisposici\u00f3n de la persona a padecer  ciertas enfermedades o trastornos. Cuando se hereda esta variante o mutaci\u00f3n, es m\u00e1s probable que se presenten s\u00edntomas, aunque esto no es seguro. Tambi\u00e9n se llama mutaci\u00f3n causal de enfermedad, mutaci\u00f3n en gen de susceptibilidad, mutaci\u00f3n predisponente y variante pat\u00f3gena.",
+        "html": "Alteraci\u00f3n gen\u00e9tica que aumenta la susceptibilidad o predisposici\u00f3n de la persona a padecer  ciertas enfermedades o trastornos. Cuando se hereda esta variante o mutaci\u00f3n, es m\u00e1s probable que se presenten s\u00edntomas, aunque esto no es seguro. Tambi\u00e9n se llama mutaci\u00f3n causal de enfermedad, mutaci\u00f3n en gen de susceptibilidad, mutaci\u00f3n predisponente y variante pat\u00f3gena."
+    },
+    "otherLanguages": [
+        {
+            "language": "en",
+            "termName": "deleterious mutation",
+            "prettyUrlName": "deleterious-mutation"
+        }
+    ],
+    "media": [],
+    "relatedResources": []
+}

--- a/integration-tests/features/terms/getById/success-fallback-title-case-cancergov-patient-en-43980.json
+++ b/integration-tests/features/terms/getById/success-fallback-title-case-cancergov-patient-en-43980.json
@@ -1,0 +1,26 @@
+{
+    "termId": 43980,
+    "language": "en",
+    "dictionary": "Cancer.gov",
+    "audience": "Patient",
+    "termName": "postoperative",
+    "firstLetter": "p",
+    "prettyUrlName": "postoperative",
+    "pronunciation": {
+        "key": "(post-AH-pruh-tiv)",
+        "audio": "https://nci-media-dev.cancer.gov/pdq/media/audio/727653.mp3"
+    },
+    "definition": {
+        "text": "After surgery.",
+        "html": "After surgery."
+        },
+    "otherLanguages": [
+        {
+            "language": "es",
+            "termName": "posoperatorio",
+            "prettyUrlName": "posoperatorio"
+        }
+    ],
+    "media": [],
+    "relatedResources": []
+}

--- a/integration-tests/features/terms/getById/success-fallback-title-case-cancergov-patient-es-43980.json
+++ b/integration-tests/features/terms/getById/success-fallback-title-case-cancergov-patient-es-43980.json
@@ -1,0 +1,26 @@
+{
+    "termId": 43980,
+    "language": "es",
+    "dictionary": "Cancer.gov",
+    "audience": "Patient",
+    "termName": "posoperatorio",
+    "firstLetter": "p",
+    "prettyUrlName": "posoperatorio",
+    "pronunciation": {
+        "key": null,
+        "audio": "https://nci-media-dev.cancer.gov/pdq/media/audio/727654.mp3"
+    },
+    "definition": {
+        "text": "Despu\u00e9s de una cirug\u00eda.",
+        "html": "Despu\u00e9s de una cirug\u00eda."
+    },
+    "otherLanguages": [
+        {
+            "language": "en",
+            "termName": "postoperative",
+            "prettyUrlName": "postoperative"
+        }
+    ],
+    "media": [],
+    "relatedResources": []
+}

--- a/integration-tests/features/terms/getById/success-fallback-title-case-genetics-hp-en-43969.json
+++ b/integration-tests/features/terms/getById/success-fallback-title-case-genetics-hp-en-43969.json
@@ -1,0 +1,26 @@
+{
+    "termId": 43969,
+    "language": "en",
+    "dictionary": "Cancer.gov",
+    "audience": "Patient",
+    "termName": "arteriogram",
+    "firstLetter": "a",
+    "prettyUrlName": "arteriogram",
+    "pronunciation": {
+        "key": "(ar-TEER-ee-oh-gram)",
+        "audio": "https://nci-media-dev.cancer.gov/pdq/media/audio/703964.mp3"
+    },
+    "definition": {
+        "text": "An x-ray of arteries. The person receives an injection of a dye that outlines the vessels on the x-ray.",
+        "html": "An x-ray of arteries. The person receives an injection of a dye that outlines the vessels on the x-ray."
+    },
+    "otherLanguages": [
+        {
+            "language": "es",
+            "termName": "arteriograma",
+            "prettyUrlName": "arteriograma"
+        }
+    ],
+    "media": [],
+    "relatedResources": []
+}

--- a/integration-tests/features/terms/getById/success-fallback-title-case-genetics-hp-en-44805.json
+++ b/integration-tests/features/terms/getById/success-fallback-title-case-genetics-hp-en-44805.json
@@ -1,0 +1,32 @@
+{
+    "termId": 44805,
+    "language": "en",
+    "dictionary": "Genetics",
+    "audience": "HealthProfessional",
+    "termName": "polymorphism",
+    "firstLetter": "p",
+    "prettyUrlName": "polymorphism",
+    "pronunciation": {
+        "key": "(PAH-lee-MOR-fih-zum)",
+        "audio": "https://nci-media-dev.cancer.gov/pdq/media/audio/705993.mp3"
+    },
+    "definition": {
+        "text": "A common variant in a specific sequence of DNA. \u201cCommon\u201d is typically defined as an allele frequency of at least 1% in the general population.",
+        "html": "A common variant in a specific sequence of DNA. \u201cCommon\u201d is typically defined as an allele frequency of at least 1% in the general population."
+    },
+    "relatedResources": [
+        {
+            "Type": "External",
+            "Text": "Polymorphism",
+            "Url": "https://www.genome.gov/genetics-glossary/Polymorphism"
+        }
+    ],
+    "otherLanguages": [
+        {
+            "language": "es",
+            "termName": "polimorfismo",
+            "prettyUrlName": "polimorfismo"
+        }
+    ],
+    "media": []
+}

--- a/integration-tests/features/terms/getById/success-fallback-title-case-genetics-hp-es-43969.json
+++ b/integration-tests/features/terms/getById/success-fallback-title-case-genetics-hp-es-43969.json
@@ -1,0 +1,26 @@
+{
+    "termId": 43969,
+    "language": "es",
+    "dictionary": "Cancer.gov",
+    "audience": "Patient",
+    "termName": "arteriograma",
+    "firstLetter": "a",
+    "prettyUrlName":"arteriograma",
+    "pronunciation": {
+        "key": null,
+        "audio": "https://nci-media-dev.cancer.gov/pdq/media/audio/703965.mp3"
+    },
+    "definition": {
+        "text": "Radiograf\u00eda de las arterias. La persona recibe una inyecci\u00f3n con un tinte que hace resaltar los vasos en la radiograf\u00eda.",
+        "html": "Radiograf\u00eda de las arterias. La persona recibe una inyecci\u00f3n con un tinte que hace resaltar los vasos en la radiograf\u00eda."
+    },
+    "otherLanguages": [
+        {
+            "language": "en",
+            "termName": "arteriogram",
+            "prettyUrlName": "arteriogram"
+        }
+    ],
+    "media": [],
+    "relatedResources": []
+}

--- a/integration-tests/features/terms/getById/success-fallback-title-case-genetics-hp-es-44805.json
+++ b/integration-tests/features/terms/getById/success-fallback-title-case-genetics-hp-es-44805.json
@@ -1,0 +1,32 @@
+{
+    "termId": 44805,
+    "language": "es",
+    "dictionary": "Genetics",
+    "audience": "HealthProfessional",
+    "termName": "polimorfismo",
+    "firstLetter": "p",
+    "prettyUrlName": "polimorfismo",
+    "pronunciation": {
+        "key": null,
+        "audio": "https://nci-media-dev.cancer.gov/pdq/media/audio/705994.mp3"
+    },
+    "definition": {
+        "text": "Variante com\u00fan en una secuencia espec\u00edfica de ADN. Normalmente el t\u00e9rmino \u201ccom\u00fan\u201d se define por una frecuencia al\u00e9lica de al menos 1\u00a0% en la poblaci\u00f3n general.",
+        "html": "Variante com\u00fan en una secuencia espec\u00edfica de ADN. Normalmente el t\u00e9rmino \u201ccom\u00fan\u201d se define por una frecuencia al\u00e9lica de al menos 1\u00a0% en la poblaci\u00f3n general."
+    },
+    "relatedResources": [
+        {
+            "Type": "External",
+            "Text": "Polimorfismo",
+            "Url": "https://www.genome.gov/es/genetics-glossary/Polimorfismo"
+        }
+    ],
+    "otherLanguages": [
+        {
+            "language": "en",
+            "termName": "polymorphism",
+            "prettyUrlName": "polymorphism"
+        }
+    ],
+    "media": []
+}

--- a/integration-tests/features/terms/getById/successFallback.feature
+++ b/integration-tests/features/terms/getById/successFallback.feature
@@ -1,0 +1,32 @@
+Feature: GetById with useFallback=true with expected success.
+
+    Background:
+        * url apiHost
+
+    Scenario Outline: Given the dictionary, audience, language, ID, and useFallback = true,
+        validate the query result.
+
+        Given path 'Terms', dictionary, audience, language, id
+        And param useFallback = true
+        When method get
+        Then status 200
+        And match response == read( expected )
+
+        Examples:
+            | dictionary | audience             | language | id       | expected                                                      |
+            | cancer.gov | Patient              | en       | 43980    | success-fallback-lower-case-cancergov-patient-en-43980.json   |
+            | Cancer.gov | Patient              | en       | 43980    | success-fallback-title-case-cancergov-patient-en-43980.json   |
+            | cancer.gov | HealthProfessional   | en       | 556486   | success-fallback-lower-case-cancergov-hp-en-556486.json       |
+            | Cancer.gov | HealthProfessional   | en       | 556486   | success-fallback-title-case-cancergov-hp-en-556486.json       |
+            | genetics   | Patient              | en       | 43969    | success-fallback-lower-case-genetics-hp-en-43969.json         |
+            | Genetics   | Patient              | en       | 43969    | success-fallback-title-case-genetics-hp-en-43969.json         |
+            | genetics   | HealthProfessional   | en       | 44805    | success-fallback-lower-case-genetics-hp-en-44805.json         |
+            | Genetics   | HealthProfessional   | en       | 44805    | success-fallback-title-case-genetics-hp-en-44805.json         |
+            | cancer.gov | Patient              | es       | 43980    | success-fallback-lower-case-cancergov-patient-es-43980.json   |
+            | Cancer.gov | Patient              | es       | 43980    | success-fallback-title-case-cancergov-patient-es-43980.json   |
+            | cancer.gov | HealthProfessional   | es       | 556486   | success-fallback-lower-case-cancergov-hp-es-556486.json       |
+            | Cancer.gov | HealthProfessional   | es       | 556486   | success-fallback-title-case-cancergov-hp-es-556486.json       |
+            | genetics   | Patient              | es       | 43969    | success-fallback-lower-case-genetics-hp-es-43969.json         |
+            | Genetics   | Patient              | es       | 43969    | success-fallback-title-case-genetics-hp-es-43969.json         |
+            | genetics   | HealthProfessional   | es       | 44805    | success-fallback-lower-case-genetics-hp-es-44805.json         |
+            | Genetics   | HealthProfessional   | es       | 44805    | success-fallback-title-case-genetics-hp-es-44805.json         |

--- a/integration-tests/features/terms/getByName/error-fallback-unknown-dictionary-hp-en-clinical-resistance.json
+++ b/integration-tests/features/terms/getByName/error-fallback-unknown-dictionary-hp-en-clinical-resistance.json
@@ -1,0 +1,3 @@
+{
+    "Message": "Could not find initial fallback combination with dictionary 'unknown' and audience 'HealthProfessional'."
+}

--- a/integration-tests/features/terms/getByName/error-fallback-unknown-dictionary-patient-en-clinical-resistance.json
+++ b/integration-tests/features/terms/getByName/error-fallback-unknown-dictionary-patient-en-clinical-resistance.json
@@ -1,0 +1,3 @@
+{
+    "Message": "Could not find initial fallback combination with dictionary 'unknown' and audience 'Patient'."
+}

--- a/integration-tests/features/terms/getByName/errorFallback.feature
+++ b/integration-tests/features/terms/getByName/errorFallback.feature
@@ -1,0 +1,18 @@
+Feature: GetByName with useFallback=true with expected errors.
+
+    Background:
+        * url apiHost
+
+    Scenario Outline: Given the dictionary, audience, language, prettyUrlName, and useFallback = true,
+        validate the error thrown.
+
+        Given path 'Terms', dictionary, audience, language, prettyUrlName
+        And param useFallback = true
+        When method get
+        Then status 404
+        And match response == read( expected )
+
+        Examples:
+            | dictionary | audience             | language | prettyUrlName         | expected                                                                |
+            | Unknown    | Patient              | en       | clinical-resistance   | error-fallback-unknown-dictionary-patient-en-clinical-resistance.json   |
+            | Unknown    | HealthProfessional   | en       | clinical-resistance   | error-fallback-unknown-dictionary-hp-en-clinical-resistance.json        |

--- a/integration-tests/features/terms/getByName/success-fallback-lower-case-cancergov-hp-en-deleterious-mutation.json
+++ b/integration-tests/features/terms/getByName/success-fallback-lower-case-cancergov-hp-en-deleterious-mutation.json
@@ -1,0 +1,26 @@
+{
+    "termId": 556486,
+    "language": "en",
+    "dictionary": "Genetics",
+    "audience": "HealthProfessional",
+    "termName": "deleterious mutation",
+    "firstLetter": "d",
+    "prettyUrlName": "deleterious-mutation",
+    "pronunciation": {
+        "key": "(DEH-leh-TEER-ee-us myoo-TAY-shun)",
+        "audio": "https://nci-media-dev.cancer.gov/pdq/media/audio/736913.mp3"
+    },
+    "definition": {
+        "text": "A genetic alteration that increases an individual\u2019s susceptibility or predisposition to a certain disease or disorder. When such a variant (or mutation) is inherited, development of symptoms is more likely, but not certain.  Also called disease-causing mutation, pathogenic variant, predisposing mutation, and susceptibility gene mutation.",
+        "html": "A genetic alteration that increases an individual\u2019s susceptibility or predisposition to a certain disease or disorder. When such a variant (or mutation) is inherited, development of symptoms is more likely, but not certain.  Also called disease-causing mutation, pathogenic variant, predisposing mutation, and susceptibility gene mutation."
+    },
+    "otherLanguages": [
+        {
+            "language": "es",
+            "termName": "mutaci\u00f3n delet\u00e9rea",
+            "prettyUrlName": "mutacion-deleterea"
+        }
+    ],
+    "media": [],
+    "relatedResources": []
+}

--- a/integration-tests/features/terms/getByName/success-fallback-lower-case-cancergov-hp-es-mutacion-deleterea.json
+++ b/integration-tests/features/terms/getByName/success-fallback-lower-case-cancergov-hp-es-mutacion-deleterea.json
@@ -1,0 +1,23 @@
+{
+    "termId": 556486,
+    "language": "es",
+    "dictionary": "Genetics",
+    "audience": "HealthProfessional",
+    "termName": "mutaci\u00f3n delet\u00e9rea",
+    "firstLetter": "m",
+    "prettyUrlName": "mutacion-deleterea",
+    "pronunciation": null,
+    "definition": {
+        "text": "Alteraci\u00f3n gen\u00e9tica que aumenta la susceptibilidad o predisposici\u00f3n de la persona a padecer  ciertas enfermedades o trastornos. Cuando se hereda esta variante o mutaci\u00f3n, es m\u00e1s probable que se presenten s\u00edntomas, aunque esto no es seguro. Tambi\u00e9n se llama mutaci\u00f3n causal de enfermedad, mutaci\u00f3n en gen de susceptibilidad, mutaci\u00f3n predisponente y variante pat\u00f3gena.",
+        "html": "Alteraci\u00f3n gen\u00e9tica que aumenta la susceptibilidad o predisposici\u00f3n de la persona a padecer  ciertas enfermedades o trastornos. Cuando se hereda esta variante o mutaci\u00f3n, es m\u00e1s probable que se presenten s\u00edntomas, aunque esto no es seguro. Tambi\u00e9n se llama mutaci\u00f3n causal de enfermedad, mutaci\u00f3n en gen de susceptibilidad, mutaci\u00f3n predisponente y variante pat\u00f3gena."
+    },
+    "otherLanguages": [
+        {
+            "language": "en",
+            "termName": "deleterious mutation",
+            "prettyUrlName": "deleterious-mutation"
+        }
+    ],
+    "media": [],
+    "relatedResources": []
+}

--- a/integration-tests/features/terms/getByName/success-fallback-lower-case-cancergov-patient-en-postoperative.json
+++ b/integration-tests/features/terms/getByName/success-fallback-lower-case-cancergov-patient-en-postoperative.json
@@ -1,0 +1,26 @@
+{
+    "termId": 43980,
+    "language": "en",
+    "dictionary": "Cancer.gov",
+    "audience": "Patient",
+    "termName": "postoperative",
+    "firstLetter": "p",
+    "prettyUrlName": "postoperative",
+    "pronunciation": {
+        "key": "(post-AH-pruh-tiv)",
+        "audio": "https://nci-media-dev.cancer.gov/pdq/media/audio/727653.mp3"
+    },
+    "definition": {
+        "text": "After surgery.",
+        "html": "After surgery."
+    },
+    "otherLanguages": [
+        {
+            "language": "es",
+            "termName": "posoperatorio",
+            "prettyUrlName": "posoperatorio"
+        }
+    ],
+    "media": [],
+    "relatedResources": []
+}

--- a/integration-tests/features/terms/getByName/success-fallback-lower-case-cancergov-patient-es-posoperatorio.json
+++ b/integration-tests/features/terms/getByName/success-fallback-lower-case-cancergov-patient-es-posoperatorio.json
@@ -1,0 +1,26 @@
+{
+    "termId": 43980,
+    "language": "es",
+    "dictionary": "Cancer.gov",
+    "audience": "Patient",
+    "termName": "posoperatorio",
+    "firstLetter": "p",
+    "prettyUrlName": "posoperatorio",
+    "pronunciation": {
+        "key": null,
+        "audio": "https://nci-media-dev.cancer.gov/pdq/media/audio/727654.mp3"
+    },
+    "definition": {
+        "text": "Despu\u00e9s de una cirug\u00eda.",
+        "html": "Despu\u00e9s de una cirug\u00eda."
+    },
+    "otherLanguages": [
+        {
+            "language": "en",
+            "termName": "postoperative",
+            "prettyUrlName": "postoperative"
+        }
+    ],
+    "media": [],
+    "relatedResources": []
+}

--- a/integration-tests/features/terms/getByName/success-fallback-lower-case-genetics-hp-en-arteriogram.json
+++ b/integration-tests/features/terms/getByName/success-fallback-lower-case-genetics-hp-en-arteriogram.json
@@ -1,0 +1,26 @@
+{
+    "termId": 43969,
+    "language": "en",
+    "dictionary": "Cancer.gov",
+    "audience": "Patient",
+    "termName": "arteriogram",
+    "firstLetter": "a",
+    "prettyUrlName": "arteriogram",
+    "pronunciation": {
+        "key": "(ar-TEER-ee-oh-gram)",
+        "audio": "https://nci-media-dev.cancer.gov/pdq/media/audio/703964.mp3"
+    },
+    "definition": {
+        "text": "An x-ray of arteries. The person receives an injection of a dye that outlines the vessels on the x-ray.",
+        "html": "An x-ray of arteries. The person receives an injection of a dye that outlines the vessels on the x-ray."
+    },
+    "otherLanguages": [
+        {
+            "language": "es",
+            "termName": "arteriograma",
+            "prettyUrlName": "arteriograma"
+        }
+    ],
+    "media": [],
+    "relatedResources": []
+}

--- a/integration-tests/features/terms/getByName/success-fallback-lower-case-genetics-hp-en-polymorphism.json
+++ b/integration-tests/features/terms/getByName/success-fallback-lower-case-genetics-hp-en-polymorphism.json
@@ -1,0 +1,32 @@
+{
+    "termId": 44805,
+    "language": "en",
+    "dictionary": "Genetics",
+    "audience": "HealthProfessional",
+    "termName": "polymorphism",
+    "firstLetter": "p",
+    "prettyUrlName": "polymorphism",
+    "pronunciation": {
+        "key": "(PAH-lee-MOR-fih-zum)",
+        "audio": "https://nci-media-dev.cancer.gov/pdq/media/audio/705993.mp3"
+    },
+    "definition": {
+        "text": "A common variant in a specific sequence of DNA. \u201cCommon\u201d is typically defined as an allele frequency of at least 1% in the general population.",
+        "html": "A common variant in a specific sequence of DNA. \u201cCommon\u201d is typically defined as an allele frequency of at least 1% in the general population."
+    },
+    "relatedResources": [
+        {
+            "Type": "External",
+            "Text": "Polymorphism",
+            "Url": "https://www.genome.gov/genetics-glossary/Polymorphism"
+        }
+    ],
+    "otherLanguages": [
+        {
+            "language": "es",
+            "termName": "polimorfismo",
+            "prettyUrlName": "polimorfismo"
+        }
+    ],
+    "media": []
+}

--- a/integration-tests/features/terms/getByName/success-fallback-lower-case-genetics-hp-es-arteriograma.json
+++ b/integration-tests/features/terms/getByName/success-fallback-lower-case-genetics-hp-es-arteriograma.json
@@ -1,0 +1,26 @@
+{
+    "termId": 43969,
+    "language": "es",
+    "dictionary": "Cancer.gov",
+    "audience": "Patient",
+    "termName": "arteriograma",
+    "firstLetter": "a",
+    "prettyUrlName":"arteriograma",
+    "pronunciation": {
+        "key": null,
+        "audio": "https://nci-media-dev.cancer.gov/pdq/media/audio/703965.mp3"
+    },
+    "definition": {
+        "text": "Radiograf\u00eda de las arterias. La persona recibe una inyecci\u00f3n con un tinte que hace resaltar los vasos en la radiograf\u00eda.",
+        "html": "Radiograf\u00eda de las arterias. La persona recibe una inyecci\u00f3n con un tinte que hace resaltar los vasos en la radiograf\u00eda."
+    },
+    "otherLanguages": [
+        {
+            "language": "en",
+            "termName": "arteriogram",
+            "prettyUrlName": "arteriogram"
+        }
+    ],
+    "media": [],
+    "relatedResources": []
+}

--- a/integration-tests/features/terms/getByName/success-fallback-lower-case-genetics-hp-es-polimorfismo.json
+++ b/integration-tests/features/terms/getByName/success-fallback-lower-case-genetics-hp-es-polimorfismo.json
@@ -1,0 +1,32 @@
+{
+    "termId": 44805,
+    "language": "es",
+    "dictionary": "Genetics",
+    "audience": "HealthProfessional",
+    "termName": "polimorfismo",
+    "firstLetter": "p",
+    "prettyUrlName": "polimorfismo",
+    "pronunciation": {
+        "key": null,
+        "audio": "https://nci-media-dev.cancer.gov/pdq/media/audio/705994.mp3"
+    },
+    "definition": {
+        "text": "Variante com\u00fan en una secuencia espec\u00edfica de ADN. Normalmente el t\u00e9rmino \u201ccom\u00fan\u201d se define por una frecuencia al\u00e9lica de al menos 1\u00a0% en la poblaci\u00f3n general.",
+        "html": "Variante com\u00fan en una secuencia espec\u00edfica de ADN. Normalmente el t\u00e9rmino \u201ccom\u00fan\u201d se define por una frecuencia al\u00e9lica de al menos 1\u00a0% en la poblaci\u00f3n general."
+    },
+    "relatedResources": [
+        {
+            "Type": "External",
+            "Text": "Polimorfismo",
+            "Url": "https://www.genome.gov/es/genetics-glossary/Polimorfismo"
+        }
+    ],
+    "otherLanguages": [
+        {
+            "language": "en",
+            "termName": "polymorphism",
+            "prettyUrlName": "polymorphism"
+        }
+    ],
+    "media": []
+}

--- a/integration-tests/features/terms/getByName/success-fallback-title-case-cancergov-hp-en-deleterious-mutation.json
+++ b/integration-tests/features/terms/getByName/success-fallback-title-case-cancergov-hp-en-deleterious-mutation.json
@@ -1,0 +1,27 @@
+{
+    "termId": 556486,
+    "language": "en",
+    "dictionary": "Genetics",
+    "audience": "HealthProfessional",
+    "termName": "deleterious mutation",
+    "firstLetter": "d",
+    "prettyUrlName": "deleterious-mutation",
+    "pronunciation": {
+        "key": "(DEH-leh-TEER-ee-us myoo-TAY-shun)",
+        "audio": "https://nci-media-dev.cancer.gov/pdq/media/audio/736913.mp3"
+    },
+    "definition": {
+        "text": "A genetic alteration that increases an individual\u2019s susceptibility or predisposition to a certain disease or disorder. When such a variant (or mutation) is inherited, development of symptoms is more likely, but not certain.  Also called disease-causing mutation, pathogenic variant, predisposing mutation, and susceptibility gene mutation.",
+        "html": "A genetic alteration that increases an individual\u2019s susceptibility or predisposition to a certain disease or disorder. When such a variant (or mutation) is inherited, development of symptoms is more likely, but not certain.  Also called disease-causing mutation, pathogenic variant, predisposing mutation, and susceptibility gene mutation."
+    },
+    "otherLanguages": [
+        {
+            "language": "es",
+            "termName": "mutaci\u00f3n delet\u00e9rea",
+            "prettyUrlName": "mutacion-deleterea"
+        }
+    ]
+    ,
+    "media": [],
+    "relatedResources": []
+}

--- a/integration-tests/features/terms/getByName/success-fallback-title-case-cancergov-hp-es-mutacion-deleterea.json
+++ b/integration-tests/features/terms/getByName/success-fallback-title-case-cancergov-hp-es-mutacion-deleterea.json
@@ -1,0 +1,23 @@
+{
+    "termId": 556486,
+    "language": "es",
+    "dictionary": "Genetics",
+    "audience": "HealthProfessional",
+    "termName": "mutaci\u00f3n delet\u00e9rea",
+    "firstLetter": "m",
+    "prettyUrlName": "mutacion-deleterea",
+    "pronunciation": null,
+    "definition": {
+        "text": "Alteraci\u00f3n gen\u00e9tica que aumenta la susceptibilidad o predisposici\u00f3n de la persona a padecer  ciertas enfermedades o trastornos. Cuando se hereda esta variante o mutaci\u00f3n, es m\u00e1s probable que se presenten s\u00edntomas, aunque esto no es seguro. Tambi\u00e9n se llama mutaci\u00f3n causal de enfermedad, mutaci\u00f3n en gen de susceptibilidad, mutaci\u00f3n predisponente y variante pat\u00f3gena.",
+        "html": "Alteraci\u00f3n gen\u00e9tica que aumenta la susceptibilidad o predisposici\u00f3n de la persona a padecer  ciertas enfermedades o trastornos. Cuando se hereda esta variante o mutaci\u00f3n, es m\u00e1s probable que se presenten s\u00edntomas, aunque esto no es seguro. Tambi\u00e9n se llama mutaci\u00f3n causal de enfermedad, mutaci\u00f3n en gen de susceptibilidad, mutaci\u00f3n predisponente y variante pat\u00f3gena."
+    },
+    "otherLanguages": [
+        {
+            "language": "en",
+            "termName": "deleterious mutation",
+            "prettyUrlName": "deleterious-mutation"
+        }
+    ],
+    "media": [],
+    "relatedResources": []
+}

--- a/integration-tests/features/terms/getByName/success-fallback-title-case-cancergov-patient-en-postoperative.json
+++ b/integration-tests/features/terms/getByName/success-fallback-title-case-cancergov-patient-en-postoperative.json
@@ -1,0 +1,26 @@
+{
+    "termId": 43980,
+    "language": "en",
+    "dictionary": "Cancer.gov",
+    "audience": "Patient",
+    "termName": "postoperative",
+    "firstLetter": "p",
+    "prettyUrlName": "postoperative",
+    "pronunciation": {
+        "key": "(post-AH-pruh-tiv)",
+        "audio": "https://nci-media-dev.cancer.gov/pdq/media/audio/727653.mp3"
+    },
+    "definition": {
+        "text": "After surgery.",
+        "html": "After surgery."
+        },
+    "otherLanguages": [
+        {
+            "language": "es",
+            "termName": "posoperatorio",
+            "prettyUrlName": "posoperatorio"
+        }
+    ],
+    "media": [],
+    "relatedResources": []
+}

--- a/integration-tests/features/terms/getByName/success-fallback-title-case-cancergov-patient-es-posoperatorio.json
+++ b/integration-tests/features/terms/getByName/success-fallback-title-case-cancergov-patient-es-posoperatorio.json
@@ -1,0 +1,26 @@
+{
+    "termId": 43980,
+    "language": "es",
+    "dictionary": "Cancer.gov",
+    "audience": "Patient",
+    "termName": "posoperatorio",
+    "firstLetter": "p",
+    "prettyUrlName": "posoperatorio",
+    "pronunciation": {
+        "key": null,
+        "audio": "https://nci-media-dev.cancer.gov/pdq/media/audio/727654.mp3"
+    },
+    "definition": {
+        "text": "Despu\u00e9s de una cirug\u00eda.",
+        "html": "Despu\u00e9s de una cirug\u00eda."
+    },
+    "otherLanguages": [
+        {
+            "language": "en",
+            "termName": "postoperative",
+            "prettyUrlName": "postoperative"
+        }
+    ],
+    "media": [],
+    "relatedResources": []
+}

--- a/integration-tests/features/terms/getByName/success-fallback-title-case-genetics-hp-en-arteriogram.json
+++ b/integration-tests/features/terms/getByName/success-fallback-title-case-genetics-hp-en-arteriogram.json
@@ -1,0 +1,26 @@
+{
+    "termId": 43969,
+    "language": "en",
+    "dictionary": "Cancer.gov",
+    "audience": "Patient",
+    "termName": "arteriogram",
+    "firstLetter": "a",
+    "prettyUrlName": "arteriogram",
+    "pronunciation": {
+        "key": "(ar-TEER-ee-oh-gram)",
+        "audio": "https://nci-media-dev.cancer.gov/pdq/media/audio/703964.mp3"
+    },
+    "definition": {
+        "text": "An x-ray of arteries. The person receives an injection of a dye that outlines the vessels on the x-ray.",
+        "html": "An x-ray of arteries. The person receives an injection of a dye that outlines the vessels on the x-ray."
+    },
+    "otherLanguages": [
+        {
+            "language": "es",
+            "termName": "arteriograma",
+            "prettyUrlName": "arteriograma"
+        }
+    ],
+    "media": [],
+    "relatedResources": []
+}

--- a/integration-tests/features/terms/getByName/success-fallback-title-case-genetics-hp-en-polymorphism.json
+++ b/integration-tests/features/terms/getByName/success-fallback-title-case-genetics-hp-en-polymorphism.json
@@ -1,0 +1,32 @@
+{
+    "termId": 44805,
+    "language": "en",
+    "dictionary": "Genetics",
+    "audience": "HealthProfessional",
+    "termName": "polymorphism",
+    "firstLetter": "p",
+    "prettyUrlName": "polymorphism",
+    "pronunciation": {
+        "key": "(PAH-lee-MOR-fih-zum)",
+        "audio": "https://nci-media-dev.cancer.gov/pdq/media/audio/705993.mp3"
+    },
+    "definition": {
+        "text": "A common variant in a specific sequence of DNA. \u201cCommon\u201d is typically defined as an allele frequency of at least 1% in the general population.",
+        "html": "A common variant in a specific sequence of DNA. \u201cCommon\u201d is typically defined as an allele frequency of at least 1% in the general population."
+    },
+    "relatedResources": [
+        {
+            "Type": "External",
+            "Text": "Polymorphism",
+            "Url": "https://www.genome.gov/genetics-glossary/Polymorphism"
+        }
+    ],
+    "otherLanguages": [
+        {
+            "language": "es",
+            "termName": "polimorfismo",
+            "prettyUrlName": "polimorfismo"
+        }
+    ],
+    "media": []
+}

--- a/integration-tests/features/terms/getByName/success-fallback-title-case-genetics-hp-es-arteriograma.json
+++ b/integration-tests/features/terms/getByName/success-fallback-title-case-genetics-hp-es-arteriograma.json
@@ -1,0 +1,26 @@
+{
+    "termId": 43969,
+    "language": "es",
+    "dictionary": "Cancer.gov",
+    "audience": "Patient",
+    "termName": "arteriograma",
+    "firstLetter": "a",
+    "prettyUrlName":"arteriograma",
+    "pronunciation": {
+        "key": null,
+        "audio": "https://nci-media-dev.cancer.gov/pdq/media/audio/703965.mp3"
+    },
+    "definition": {
+        "text": "Radiograf\u00eda de las arterias. La persona recibe una inyecci\u00f3n con un tinte que hace resaltar los vasos en la radiograf\u00eda.",
+        "html": "Radiograf\u00eda de las arterias. La persona recibe una inyecci\u00f3n con un tinte que hace resaltar los vasos en la radiograf\u00eda."
+    },
+    "otherLanguages": [
+        {
+            "language": "en",
+            "termName": "arteriogram",
+            "prettyUrlName": "arteriogram"
+        }
+    ],
+    "media": [],
+    "relatedResources": []
+}

--- a/integration-tests/features/terms/getByName/success-fallback-title-case-genetics-hp-es-polimorfismo.json
+++ b/integration-tests/features/terms/getByName/success-fallback-title-case-genetics-hp-es-polimorfismo.json
@@ -1,0 +1,32 @@
+{
+    "termId": 44805,
+    "language": "es",
+    "dictionary": "Genetics",
+    "audience": "HealthProfessional",
+    "termName": "polimorfismo",
+    "firstLetter": "p",
+    "prettyUrlName": "polimorfismo",
+    "pronunciation": {
+        "key": null,
+        "audio": "https://nci-media-dev.cancer.gov/pdq/media/audio/705994.mp3"
+    },
+    "definition": {
+        "text": "Variante com\u00fan en una secuencia espec\u00edfica de ADN. Normalmente el t\u00e9rmino \u201ccom\u00fan\u201d se define por una frecuencia al\u00e9lica de al menos 1\u00a0% en la poblaci\u00f3n general.",
+        "html": "Variante com\u00fan en una secuencia espec\u00edfica de ADN. Normalmente el t\u00e9rmino \u201ccom\u00fan\u201d se define por una frecuencia al\u00e9lica de al menos 1\u00a0% en la poblaci\u00f3n general."
+    },
+    "relatedResources": [
+        {
+            "Type": "External",
+            "Text": "Polimorfismo",
+            "Url": "https://www.genome.gov/es/genetics-glossary/Polimorfismo"
+        }
+    ],
+    "otherLanguages": [
+        {
+            "language": "en",
+            "termName": "polymorphism",
+            "prettyUrlName": "polymorphism"
+        }
+    ],
+    "media": []
+}

--- a/integration-tests/features/terms/getByName/successFallback.feature
+++ b/integration-tests/features/terms/getByName/successFallback.feature
@@ -1,0 +1,32 @@
+Feature: GetByName with useFallback=true with expected success.
+
+    Background:
+        * url apiHost
+
+    Scenario Outline: Given the dictionary, audience, language, prettyUrlName, and useFallback = true,
+        validate the query result.
+
+        Given path 'Terms', dictionary, audience, language, prettyUrlName
+        And param useFallback = true
+        When method get
+        Then status 200
+        And match response == read( expected )
+
+        Examples:
+            | dictionary | audience             | language | prettyUrlName          | expected                                                                    |
+            | cancer.gov | Patient              | en       | postoperative          | success-fallback-lower-case-cancergov-patient-en-postoperative.json         |
+            | Cancer.gov | Patient              | en       | postoperative          | success-fallback-title-case-cancergov-patient-en-postoperative.json         |
+            | cancer.gov | HealthProfessional   | en       | deleterious-mutation   | success-fallback-lower-case-cancergov-hp-en-deleterious-mutation.json       |
+            | Cancer.gov | HealthProfessional   | en       | deleterious-mutation   | success-fallback-title-case-cancergov-hp-en-deleterious-mutation.json       |
+            | genetics   | Patient              | en       | arteriogram            | success-fallback-lower-case-genetics-hp-en-arteriogram.json                 |
+            | Genetics   | Patient              | en       | arteriogram            | success-fallback-title-case-genetics-hp-en-arteriogram.json                 |
+            | genetics   | HealthProfessional   | en       | polymorphism           | success-fallback-lower-case-genetics-hp-en-polymorphism.json                |
+            | Genetics   | HealthProfessional   | en       | polymorphism           | success-fallback-title-case-genetics-hp-en-polymorphism.json                |
+            | cancer.gov | Patient              | es       | posoperatorio          | success-fallback-lower-case-cancergov-patient-es-posoperatorio.json         |
+            | Cancer.gov | Patient              | es       | posoperatorio          | success-fallback-title-case-cancergov-patient-es-posoperatorio.json         |
+            | cancer.gov | HealthProfessional   | es       | mutacion-deleterea     | success-fallback-lower-case-cancergov-hp-es-mutacion-deleterea.json         |
+            | Cancer.gov | HealthProfessional   | es       | mutacion-deleterea     | success-fallback-title-case-cancergov-hp-es-mutacion-deleterea.json         |
+            | genetics   | Patient              | es       | arteriograma           | success-fallback-lower-case-genetics-hp-es-arteriograma.json                |
+            | Genetics   | Patient              | es       | arteriograma           | success-fallback-title-case-genetics-hp-es-arteriograma.json                |
+            | genetics   | HealthProfessional   | es       | polimorfismo           | success-fallback-lower-case-genetics-hp-es-polimorfismo.json                |
+            | Genetics   | HealthProfessional   | es       | polimorfismo           | success-fallback-title-case-genetics-hp-es-polimorfismo.json                |

--- a/test/NCI.OCPL.Api.Glossary.Tests/Tests/Controllers/TermsControllerTest.GetByName.cs
+++ b/test/NCI.OCPL.Api.Glossary.Tests/Tests/Controllers/TermsControllerTest.GetByName.cs
@@ -128,7 +128,7 @@ namespace NCI.OCPL.Api.Glossary.Tests
             //  a) with the expected values.
             //  b) exactly once.
             termsQueryService.Verify(
-                svc => svc.GetByName("Cancer.gov", AudienceType.Patient, "en", "s-phase-fraction"),
+                svc => svc.GetByName("cancer.gov", AudienceType.Patient, "en", "s-phase-fraction"),
                 Times.Once
             );
 
@@ -173,55 +173,55 @@ namespace NCI.OCPL.Api.Glossary.Tests
             // Cancer.gov and HealthProfessional would be the first call to the terms query service, returning nothing.
             termQueryService.Setup(
                 termQSvc => termQSvc.GetByName(
-                    It.Is<String>(dictionary => dictionary == "Cancer.gov"),
+                    It.Is<String>(dictionary => dictionary == "cancer.gov"),
                     It.Is<AudienceType>(audience => audience == AudienceType.HealthProfessional),
                     It.Is<string>(language => language == "en"),
                     It.Is<string>(prettyUrlName => prettyUrlName == "deleterious-mutation")
                 )
             )
             .Callback(() => Assert.Equal(1, callOrder++))
-            .Throws(new APIErrorException(200, "Empty response when searching for dictionary 'Cancer.gov', audience 'HealthProfessional', language 'en', pretty URL name 'deleterious-mutation'."));
+            .Throws(new APIErrorException(200, "Empty response when searching for dictionary 'cancer.gov', audience 'HealthProfessional', language 'en', pretty URL name 'deleterious-mutation'."));
 
             // Cancer.gov and Patient would be the second call to the terms query service, returning nothing.
             termQueryService.Setup(
                 termQSvc => termQSvc.GetByName(
-                    It.Is<String>(dictionary => dictionary == "Cancer.gov"),
+                    It.Is<String>(dictionary => dictionary == "cancer.gov"),
                     It.Is<AudienceType>(audience => audience == AudienceType.Patient),
                     It.Is<string>(language => language == "en"),
                     It.Is<string>(prettyUrlName => prettyUrlName == "deleterious-mutation")
                 )
             )
             .Callback(() => Assert.Equal(2, callOrder++))
-            .Throws(new APIErrorException(200, "Empty response when searching for dictionary 'Cancer.gov', audience 'Patient', language 'en', pretty URL name 'deleterious-mutation'."));
+            .Throws(new APIErrorException(200, "Empty response when searching for dictionary 'cancer.gov', audience 'Patient', language 'en', pretty URL name 'deleterious-mutation'."));
 
             // NotSet and HealthProfessional would be the third call to the terms query service, returning nothing.
             termQueryService.Setup(
                 termQSvc => termQSvc.GetByName(
-                    It.Is<String>(dictionary => dictionary == "NotSet"),
+                    It.Is<String>(dictionary => dictionary == "notset"),
                     It.Is<AudienceType>(audience => audience == AudienceType.HealthProfessional),
                     It.Is<string>(language => language == "en"),
                     It.Is<string>(prettyUrlName => prettyUrlName == "deleterious-mutation")
                 )
             )
             .Callback(() => Assert.Equal(3, callOrder++))
-            .Throws(new APIErrorException(200, "Empty response when searching for dictionary 'NotSet', audience 'HealthProfessional', language 'en', pretty URL name 'deleterious-mutation'."));
+            .Throws(new APIErrorException(200, "Empty response when searching for dictionary 'notset', audience 'HealthProfessional', language 'en', pretty URL name 'deleterious-mutation'."));
 
             // NotSet and Patient would be the fourth call to the terms query service, returning nothing.
             termQueryService.Setup(
                 termQSvc => termQSvc.GetByName(
-                    It.Is<String>(dictionary => dictionary == "NotSet"),
+                    It.Is<String>(dictionary => dictionary == "notset"),
                     It.Is<AudienceType>(audience => audience == AudienceType.Patient),
                     It.Is<string>(language => language == "en"),
                     It.Is<string>(prettyUrlName => prettyUrlName == "deleterious-mutation")
                 )
             )
             .Callback(() => Assert.Equal(4, callOrder++))
-            .Throws(new APIErrorException(200, "Empty response when searching for dictionary 'NotSet', audience 'Patient', language 'en', pretty URL name 'deleterious-mutation'."));
+            .Throws(new APIErrorException(200, "Empty response when searching for dictionary 'notset', audience 'Patient', language 'en', pretty URL name 'deleterious-mutation'."));
 
             // Genetics and HealthProfessional would be the last call to the terms query service, returning the term.
             termQueryService.Setup(
                 termQSvc => termQSvc.GetByName(
-                    It.Is<String>(dictionary => dictionary == "Genetics"),
+                    It.Is<String>(dictionary => dictionary == "genetics"),
                     It.Is<AudienceType>(audience => audience == AudienceType.HealthProfessional),
                     It.Is<string>(language => language == "en"),
                     It.Is<string>(prettyUrlName => prettyUrlName == "deleterious-mutation")
@@ -240,27 +240,27 @@ namespace NCI.OCPL.Api.Glossary.Tests
             // Verify that the service layer is called correctly with the fallback logic:
             // 1) Cancer.gov, HealthProfessional
             termQueryService.Verify(
-                svc => svc.GetByName("Cancer.gov", AudienceType.HealthProfessional, "en", "deleterious-mutation"),
+                svc => svc.GetByName("cancer.gov", AudienceType.HealthProfessional, "en", "deleterious-mutation"),
                 Times.Once
             );
             // 2) Cancer.gov, Patient
             termQueryService.Verify(
-                svc => svc.GetByName("Cancer.gov", AudienceType.Patient, "en", "deleterious-mutation"),
+                svc => svc.GetByName("cancer.gov", AudienceType.Patient, "en", "deleterious-mutation"),
                 Times.Once
             );
             // 3) Empty dictionary, HealthProfessional
             termQueryService.Verify(
-                svc => svc.GetByName("NotSet", AudienceType.HealthProfessional, "en", "deleterious-mutation"),
+                svc => svc.GetByName("notset", AudienceType.HealthProfessional, "en", "deleterious-mutation"),
                 Times.Once
             );
             // 4) Empty dictionary, Patient
             termQueryService.Verify(
-                svc => svc.GetByName("NotSet", AudienceType.Patient, "en", "deleterious-mutation"),
+                svc => svc.GetByName("notset", AudienceType.Patient, "en", "deleterious-mutation"),
                 Times.Once
             );
             // 5) Genetics, HealthProfessional
             termQueryService.Verify(
-                svc => svc.GetByName("Genetics", AudienceType.HealthProfessional, "en", "deleterious-mutation"),
+                svc => svc.GetByName("genetics", AudienceType.HealthProfessional, "en", "deleterious-mutation"),
                 Times.Once
             );
         }
@@ -303,55 +303,55 @@ namespace NCI.OCPL.Api.Glossary.Tests
             // NotSet and Patient would be the first call to the terms query service, returning nothing.
             termQueryService.Setup(
                 termQSvc => termQSvc.GetByName(
-                    It.Is<String>(dictionary => dictionary == "NotSet"),
+                    It.Is<String>(dictionary => dictionary == "notset"),
                     It.Is<AudienceType>(audience => audience == AudienceType.Patient),
                     It.Is<string>(language => language == "en"),
                     It.Is<string>(prettyUrlName => prettyUrlName == "s-phase-fraction")
                 )
             )
             .Callback(() => Assert.Equal(1, callOrder++))
-            .Throws(new APIErrorException(200, "Empty response when searching for dictionary 'NotSet', audience 'Patient', language 'en', pretty URL name 's-phase-fraction'."));
+            .Throws(new APIErrorException(200, "Empty response when searching for dictionary 'notset', audience 'Patient', language 'en', pretty URL name 's-phase-fraction'."));
 
             // NotSet and HealthProfessional would be the second call to the terms query service, returning nothing.
             termQueryService.Setup(
                 termQSvc => termQSvc.GetByName(
-                    It.Is<String>(dictionary => dictionary == "NotSet"),
+                    It.Is<String>(dictionary => dictionary == "notset"),
                     It.Is<AudienceType>(audience => audience == AudienceType.HealthProfessional),
                     It.Is<string>(language => language == "en"),
                     It.Is<string>(prettyUrlName => prettyUrlName == "s-phase-fraction")
                 )
             )
             .Callback(() => Assert.Equal(2, callOrder++))
-            .Throws(new APIErrorException(200, "Empty response when searching for dictionary 'NotSet', audience 'HealthProfessional', language 'en', pretty URL name 's-phase-fraction'."));
+            .Throws(new APIErrorException(200, "Empty response when searching for dictionary 'notset', audience 'HealthProfessional', language 'en', pretty URL name 's-phase-fraction'."));
 
             // Genetics and Patient would be the third call to the terms query service, returning nothing.
             termQueryService.Setup(
                 termQSvc => termQSvc.GetByName(
-                    It.Is<String>(dictionary => dictionary == "Genetics"),
+                    It.Is<String>(dictionary => dictionary == "genetics"),
                     It.Is<AudienceType>(audience => audience == AudienceType.Patient),
                     It.Is<string>(language => language == "en"),
                     It.Is<string>(prettyUrlName => prettyUrlName == "s-phase-fraction")
                 )
             )
             .Callback(() => Assert.Equal(3, callOrder++))
-            .Throws(new APIErrorException(200, "Empty response when searching for dictionary 'Genetics', audience 'Patient', language 'en', pretty URL name 's-phase-fraction'."));
+            .Throws(new APIErrorException(200, "Empty response when searching for dictionary 'genetics', audience 'Patient', language 'en', pretty URL name 's-phase-fraction'."));
 
             // Genetics and HealthProfessional would be the fourth call to the terms query service, returning nothing.
             termQueryService.Setup(
                 termQSvc => termQSvc.GetByName(
-                    It.Is<String>(dictionary => dictionary == "Genetics"),
+                    It.Is<String>(dictionary => dictionary == "genetics"),
                     It.Is<AudienceType>(audience => audience == AudienceType.HealthProfessional),
                     It.Is<string>(language => language == "en"),
                     It.Is<string>(prettyUrlName => prettyUrlName == "s-phase-fraction")
                 )
             )
             .Callback(() => Assert.Equal(4, callOrder++))
-            .Throws(new APIErrorException(200, "Empty response when searching for dictionary 'Genetics', audience 'HealthProfessional', language 'en', pretty URL name 's-phase-fraction'."));
+            .Throws(new APIErrorException(200, "Empty response when searching for dictionary 'genetics', audience 'HealthProfessional', language 'en', pretty URL name 's-phase-fraction'."));
 
             // Cancer.gov and Patient would be the last call to the terms query service, returning the term.
             termQueryService.Setup(
                 termQSvc => termQSvc.GetByName(
-                    It.Is<String>(dictionary => dictionary == "Cancer.gov"),
+                    It.Is<String>(dictionary => dictionary == "cancer.gov"),
                     It.Is<AudienceType>(audience => audience == AudienceType.Patient),
                     It.Is<string>(language => language == "en"),
                     It.Is<string>(prettyUrlName => prettyUrlName == "s-phase-fraction")
@@ -370,29 +370,103 @@ namespace NCI.OCPL.Api.Glossary.Tests
             // Verify that the service layer is called correctly with the fallback logic:
             // 1) Empty dictionary, Patient
             termQueryService.Verify(
-                svc => svc.GetByName("NotSet", AudienceType.Patient, "en", "s-phase-fraction"),
+                svc => svc.GetByName("notset", AudienceType.Patient, "en", "s-phase-fraction"),
                 Times.Once
             );
             // 2) Empty dictionary, HealthProfessional
             termQueryService.Verify(
-                svc => svc.GetByName("NotSet", AudienceType.HealthProfessional, "en", "s-phase-fraction"),
+                svc => svc.GetByName("notset", AudienceType.HealthProfessional, "en", "s-phase-fraction"),
                 Times.Once
             );
             // 3) Genetics, Patient
             termQueryService.Verify(
-                svc => svc.GetByName("Genetics", AudienceType.Patient, "en", "s-phase-fraction"),
+                svc => svc.GetByName("genetics", AudienceType.Patient, "en", "s-phase-fraction"),
                 Times.Once
             );
             // 4) Genetics, HealthProfessional
             termQueryService.Verify(
-                svc => svc.GetByName("Genetics", AudienceType.HealthProfessional, "en", "s-phase-fraction"),
+                svc => svc.GetByName("genetics", AudienceType.HealthProfessional, "en", "s-phase-fraction"),
                 Times.Once
             );
             // 5) Cancer.gov, Patient
             termQueryService.Verify(
-                svc => svc.GetByName("Cancer.gov", AudienceType.Patient, "en", "s-phase-fraction"),
+                svc => svc.GetByName("cancer.gov", AudienceType.Patient, "en", "s-phase-fraction"),
                 Times.Once
             );
+        }
+
+        // This test is for the fallback logic of GetByName.
+        // It tests whether a known dictionary passed in, regardless of TitleCase, will be found in the fallback combinations,
+        // and that the expected calls are made and objects returned.
+        // The expected return from the terms query service for the call expected to be made is set up.
+        // It performs the call to the controller with the correct params.
+        // It verifies that the expected and actual glossaryTerm objects are the same.
+        // It verifies that the query service was called the expected number of times with the expected params.
+        [Fact]
+        public async void GetByName_WithFallback_TermsPatient_NotTitleCase()
+        {
+            Mock<ITermsQueryService> termQueryService = new Mock<ITermsQueryService>();
+            GlossaryTerm glossaryTerm = new GlossaryTerm()
+            {
+                TermId = 44771,
+                Language = "en",
+                Dictionary = "Cancer.gov",
+                Audience = AudienceType.Patient,
+                TermName = "S-phase fraction",
+                FirstLetter = "s",
+                PrettyUrlName = "s-phase-fraction",
+                Definition = new Definition()
+                {
+                    Text = "A measure of the percentage of cells in a tumor that are in the phase of the cell cycle during which DNA is synthesized. The S-phase fraction may be used with the proliferative index to give a more complete understanding of how fast a tumor is growing.",
+                    Html = "A measure of the percentage of cells in a tumor that are in the phase of the cell cycle during which DNA is synthesized. The S-phase fraction may be used with the proliferative index to give a more complete understanding of how fast a tumor is growing."
+                },
+                Pronunciation = new Pronunciation()
+                {
+                    Key = "(... fayz FRAK-shun)",
+                    Audio = "https://nci-media-dev.cancer.gov/audio/pdq/705947.mp3"
+                },
+                Media = new IMedia[] { },
+                RelatedResources = new IRelatedResource[] { }
+            };
+
+            // "cancer.gov" (not the requested "Cancer.gov") and Patient would be the only call to the terms query service, returning the term.
+            termQueryService.Setup(
+                termQSvc => termQSvc.GetByName(
+                    It.Is<String>(dictionary => dictionary == "cancer.gov"),
+                    It.Is<AudienceType>(audience => audience == AudienceType.Patient),
+                    It.Is<string>(language => language == "en"),
+                    It.Is<string>(prettyUrlName => prettyUrlName == "s-phase-fraction")
+                )
+            )
+            .Returns(Task.FromResult(glossaryTerm));
+
+            TermsController controller = new TermsController(NullLogger<TermsController>.Instance, termQueryService.Object);
+            GlossaryTerm gsTerm = await controller.GetByName("Cancer.gov", AudienceType.Patient, "en", "s-phase-fraction", true);
+
+            // Verify that the expected and actual Term are the same.
+            JObject actual = JObject.Parse(JsonConvert.SerializeObject(gsTerm));
+            JObject expected = JObject.Parse(File.ReadAllText(TestingTools.GetPathToTestFile("TermsControllerData/TestData_GetWithFallback_TermsPatient.json")));
+            Assert.Equal(expected, actual, new JTokenEqualityComparer());
+
+            // Verify that the service layer is called correctly with the lowercased-dictionary fallback combination:
+            termQueryService.Verify(
+                svc => svc.GetByName("cancer.gov", AudienceType.Patient, "en", "s-phase-fraction"),
+                Times.Once
+            );
+        }
+
+        // This test is for the fallback logic in GetByName when the dictionary name is not one that is known (Cancer.gov, Genetics, or NotSet).
+        // Unlike the other fallback tests, this confirms that dictionary and audience combinations that are not known fallback combinations
+        // are identified and cause errors to occur.
+        // This is expected to throw a 404.
+        [Fact]
+        public async void GetByName_WithFallback_ErrorMessage_UnknownCombination()
+        {
+            Mock<ITermsQueryService> termQueryService = new Mock<ITermsQueryService>();
+            TermsController controller = new TermsController(NullLogger<TermsController>.Instance, termQueryService.Object);
+            var exception = await Assert.ThrowsAsync<APIErrorException>(() => controller.GetByName("UnknownDictionary", AudienceType.Patient, "EN", "s-phase-fraction", true));
+            Assert.Equal(404, exception.HttpStatusCode);
+            Assert.Equal("Could not find initial fallback combination with dictionary 'unknowndictionary' and audience 'Patient'.", exception.Message);
         }
     }
 }

--- a/test/NCI.OCPL.Api.Glossary.Tests/Tests/Controllers/TermsControllerTest.cs
+++ b/test/NCI.OCPL.Api.Glossary.Tests/Tests/Controllers/TermsControllerTest.cs
@@ -121,7 +121,7 @@ namespace NCI.OCPL.Api.Glossary.Tests
             // a) with the expected values.
             // b) exactly once.
             termQueryService.Verify(
-                svc => svc.GetById("Dictionary", AudienceType.Patient, "EN", 1234L),
+                svc => svc.GetById("dictionary", AudienceType.Patient, "EN", 1234L),
                 Times.Once
             );
 
@@ -200,7 +200,7 @@ namespace NCI.OCPL.Api.Glossary.Tests
             // a) with the expected values.
             // b) exactly once.
             termQueryService.Verify(
-                svc => svc.GetById("Dictionary", AudienceType.Patient, "EN", 1234L),
+                svc => svc.GetById("dictionary", AudienceType.Patient, "EN", 1234L),
                 Times.Once
             );
 
@@ -245,54 +245,54 @@ namespace NCI.OCPL.Api.Glossary.Tests
             // Cancer.gov and HealthProfessional would be the first call to the terms query service, returning nothing.
             termQueryService.Setup(
                 termQSvc => termQSvc.GetById(
-                    It.Is<String>(dictionary => dictionary == "Cancer.gov"),
+                    It.Is<String>(dictionary => dictionary == "cancer.gov"),
                     It.Is<AudienceType>(audience => audience == AudienceType.HealthProfessional),
                     It.Is<string>(language => language == "en"),
                     It.Is<long>(id => id == 556486)
                 )
             )
             .Callback(() => Assert.Equal(1, callOrder++))
-            .Throws(new APIErrorException(200, "Empty response when searching for dictionary 'Cancer.gov', audience 'HealthProfessional', language 'en' and id '556486'."));
+            .Throws(new APIErrorException(200, "Empty response when searching for dictionary 'cancer.gov', audience 'HealthProfessional', language 'en' and id '556486'."));
 
             // Cancer.gov and Patient would be the second call to the terms query service, returning nothing.
             termQueryService.Setup(termQSvc => termQSvc.GetById(
-                    It.Is<String>(dictionary => dictionary == "Cancer.gov"),
+                    It.Is<String>(dictionary => dictionary == "cancer.gov"),
                     It.Is<AudienceType>(audience => audience == AudienceType.Patient),
                     It.Is<string>(language => language == "en"),
                     It.Is<long>(id => id == 556486)
                 )
             )
             .Callback(() => Assert.Equal(2, callOrder++))
-            .Throws(new APIErrorException(200, "Empty response when searching for dictionary 'Cancer.gov', audience 'Patient', language 'en' and id '556486'."));
+            .Throws(new APIErrorException(200, "Empty response when searching for dictionary 'cancer.gov', audience 'Patient', language 'en' and id '556486'."));
 
             // NotSet and HealthProfessional would be the third call to the terms query service, returning nothing.
             termQueryService.Setup(
                 termQSvc => termQSvc.GetById(
-                    It.Is<String>(dictionary => dictionary == "NotSet"),
+                    It.Is<String>(dictionary => dictionary == "notset"),
                     It.Is<AudienceType>(audience => audience == AudienceType.HealthProfessional),
                     It.Is<string>(language => language == "en"),
                     It.Is<long>(id => id == 556486)
                 )
             )
             .Callback(() => Assert.Equal(3, callOrder++))
-            .Throws(new APIErrorException(200, "Empty response when searching for dictionary 'NotSet', audience 'HealthProfessional', language 'en' and id '556486'."));
+            .Throws(new APIErrorException(200, "Empty response when searching for dictionary 'notset', audience 'HealthProfessional', language 'en' and id '556486'."));
 
             // NotSet and Patient would be the fourth call to the terms query service, returning nothing.
             termQueryService.Setup(
                 termQSvc => termQSvc.GetById(
-                    It.Is<String>(dictionary => dictionary == "NotSet"),
+                    It.Is<String>(dictionary => dictionary == "notset"),
                     It.Is<AudienceType>(audience => audience == AudienceType.Patient),
                     It.Is<string>(language => language == "en"),
                     It.Is<long>(id => id == 556486)
                 )
             )
             .Callback(() => Assert.Equal(4, callOrder++))
-            .Throws(new APIErrorException(200, "Empty response when searching for dictionary 'NotSet', audience 'Patient', language 'en' and id '556486'."));
+            .Throws(new APIErrorException(200, "Empty response when searching for dictionary 'notset', audience 'Patient', language 'en' and id '556486'."));
 
             // Genetics and HealthProfessional would be the last call to the terms query service, returning the term.
             termQueryService.Setup(
                 termQSvc => termQSvc.GetById(
-                    It.Is<String>(dictionary => dictionary == "Genetics"),
+                    It.Is<String>(dictionary => dictionary == "genetics"),
                     It.Is<AudienceType>(audience => audience == AudienceType.HealthProfessional),
                     It.Is<string>(language => language == "en"),
                     It.Is<long>(id => id == 556486)
@@ -311,27 +311,27 @@ namespace NCI.OCPL.Api.Glossary.Tests
             // Verify that the service layer is called correctly with the fallback logic:
             // 1) Cancer.gov, HealthProfessional
             termQueryService.Verify(
-                svc => svc.GetById("Cancer.gov", AudienceType.HealthProfessional, "en", 556486),
+                svc => svc.GetById("cancer.gov", AudienceType.HealthProfessional, "en", 556486),
                 Times.Once
             );
             // 2) Cancer.gov, Patient
             termQueryService.Verify(
-                svc => svc.GetById("Cancer.gov", AudienceType.Patient, "en", 556486),
+                svc => svc.GetById("cancer.gov", AudienceType.Patient, "en", 556486),
                 Times.Once
             );
             // 3) Empty dictionary, HealthProfessional
             termQueryService.Verify(
-                svc => svc.GetById("NotSet", AudienceType.HealthProfessional, "en", 556486),
+                svc => svc.GetById("notset", AudienceType.HealthProfessional, "en", 556486),
                 Times.Once
             );
             // 4) Empty dictionary, Patient
             termQueryService.Verify(
-                svc => svc.GetById("NotSet", AudienceType.Patient, "en", 556486),
+                svc => svc.GetById("notset", AudienceType.Patient, "en", 556486),
                 Times.Once
             );
             // 5) Genetics, HealthProfessional
             termQueryService.Verify(
-                svc => svc.GetById("Genetics", AudienceType.HealthProfessional, "en", 556486),
+                svc => svc.GetById("genetics", AudienceType.HealthProfessional, "en", 556486),
                 Times.Once
             );
         }
@@ -374,55 +374,55 @@ namespace NCI.OCPL.Api.Glossary.Tests
             // NotSet and Patient would be the first call to the terms query service, returning nothing.
             termQueryService.Setup(
                 termQSvc => termQSvc.GetById(
-                    It.Is<String>(dictionary => dictionary == "NotSet"),
+                    It.Is<String>(dictionary => dictionary == "notset"),
                     It.Is<AudienceType>(audience => audience == AudienceType.Patient),
                     It.Is<string>(language => language == "en"),
                     It.Is<long>(id => id == 44771)
                 )
             )
             .Callback(() => Assert.Equal(1, callOrder++))
-            .Throws(new APIErrorException(200, "Empty response when searching for dictionary 'NotSet', audience 'Patient', language 'en' and id '44771'."));
+            .Throws(new APIErrorException(200, "Empty response when searching for dictionary 'notset', audience 'Patient', language 'en' and id '44771'."));
 
             // NotSet and HealthProfessional would be the second call to the terms query service, returning nothing.
             termQueryService.Setup(
                 termQSvc => termQSvc.GetById(
-                    It.Is<String>(dictionary => dictionary == "NotSet"),
+                    It.Is<String>(dictionary => dictionary == "notset"),
                     It.Is<AudienceType>(audience => audience == AudienceType.HealthProfessional),
                     It.Is<string>(language => language == "en"),
                     It.Is<long>(id => id == 44771)
                 )
             )
             .Callback(() => Assert.Equal(2, callOrder++))
-            .Throws(new APIErrorException(200, "Empty response when searching for dictionary 'NotSet', audience 'HealthProfessional', language 'en' and id '44771'."));
+            .Throws(new APIErrorException(200, "Empty response when searching for dictionary 'notset', audience 'HealthProfessional', language 'en' and id '44771'."));
 
             // Genetics and Patient would be the third call to the terms query service, returning nothing.
             termQueryService.Setup(
                 termQSvc => termQSvc.GetById(
-                    It.Is<String>(dictionary => dictionary == "Genetics"),
+                    It.Is<String>(dictionary => dictionary == "genetics"),
                     It.Is<AudienceType>(audience => audience == AudienceType.Patient),
                     It.Is<string>(language => language == "en"),
                     It.Is<long>(id => id == 44771)
                 )
             )
             .Callback(() => Assert.Equal(3, callOrder++))
-            .Throws(new APIErrorException(200, "Empty response when searching for dictionary 'Genetics', audience 'Patient', language 'en' and id '44771'."));
+            .Throws(new APIErrorException(200, "Empty response when searching for dictionary 'genetics', audience 'Patient', language 'en' and id '44771'."));
 
             // Genetics and HealthProfessional would be the fourth call to the terms query service, returning nothing.
             termQueryService.Setup(
                 termQSvc => termQSvc.GetById(
-                    It.Is<String>(dictionary => dictionary == "Genetics"),
+                    It.Is<String>(dictionary => dictionary == "genetics"),
                     It.Is<AudienceType>(audience => audience == AudienceType.HealthProfessional),
                     It.Is<string>(language => language == "en"),
                     It.Is<long>(id => id == 44771)
                 )
             )
             .Callback(() => Assert.Equal(4, callOrder++))
-            .Throws(new APIErrorException(200, "Empty response when searching for dictionary 'Genetics', audience 'HealthProfessional', language 'en' and id '44771'."));
+            .Throws(new APIErrorException(200, "Empty response when searching for dictionary 'genetics', audience 'HealthProfessional', language 'en' and id '44771'."));
 
             // Cancer.gov and Patient would be the last call to the terms query service, returning the term.
             termQueryService.Setup(
                 termQSvc => termQSvc.GetById(
-                    It.Is<String>(dictionary => dictionary == "Cancer.gov"),
+                    It.Is<String>(dictionary => dictionary == "cancer.gov"),
                     It.Is<AudienceType>(audience => audience == AudienceType.Patient),
                     It.Is<string>(language => language == "en"),
                     It.Is<long>(id => id == 44771)
@@ -441,29 +441,103 @@ namespace NCI.OCPL.Api.Glossary.Tests
             // Verify that the service layer is called correctly with the fallback logic:
             // 1) Empty dictionary, Patient
             termQueryService.Verify(
-                svc => svc.GetById("NotSet", AudienceType.Patient, "en", 44771),
+                svc => svc.GetById("notset", AudienceType.Patient, "en", 44771),
                 Times.Once
             );
             // 2) Empty dictionary, HealthProfessional
             termQueryService.Verify(
-                svc => svc.GetById("NotSet", AudienceType.HealthProfessional, "en", 44771),
+                svc => svc.GetById("notset", AudienceType.HealthProfessional, "en", 44771),
                 Times.Once
             );
             // 3) Genetics, Patient
             termQueryService.Verify(
-                svc => svc.GetById("Genetics", AudienceType.Patient, "en", 44771),
+                svc => svc.GetById("genetics", AudienceType.Patient, "en", 44771),
                 Times.Once
             );
             // 4) Genetics, HealthProfessional
             termQueryService.Verify(
-                svc => svc.GetById("Genetics", AudienceType.HealthProfessional, "en", 44771),
+                svc => svc.GetById("genetics", AudienceType.HealthProfessional, "en", 44771),
                 Times.Once
             );
             // 5) Cancer.gov, Patient
             termQueryService.Verify(
-                svc => svc.GetById("Cancer.gov", AudienceType.Patient, "en", 44771),
+                svc => svc.GetById("cancer.gov", AudienceType.Patient, "en", 44771),
                 Times.Once
             );
+        }
+
+        // This test is for the fallback logic of GetById.
+        // It tests whether a known dictionary passed in, regardless of TitleCase, will be found in the fallback combinations,
+        // and that the expected calls are made and objects returned.
+        // The expected return from the terms query service for the call expected to be made is set up.
+        // It performs the call to the controller with the correct params.
+        // It verifies that the expected and actual glossaryTerm objects are the same.
+        // It verifies that the query service was called the expected number of times with the expected params.
+        [Fact]
+        public async void GetById_WithFallback_TermsPatient_NotTitleCase()
+        {
+            Mock<ITermsQueryService> termQueryService = new Mock<ITermsQueryService>();
+            GlossaryTerm glossaryTerm = new GlossaryTerm()
+            {
+                TermId = 44771,
+                Language = "en",
+                Dictionary = "Cancer.gov",
+                Audience = AudienceType.Patient,
+                TermName = "S-phase fraction",
+                FirstLetter = "s",
+                PrettyUrlName = "s-phase-fraction",
+                Definition = new Definition()
+                {
+                    Text = "A measure of the percentage of cells in a tumor that are in the phase of the cell cycle during which DNA is synthesized. The S-phase fraction may be used with the proliferative index to give a more complete understanding of how fast a tumor is growing.",
+                    Html = "A measure of the percentage of cells in a tumor that are in the phase of the cell cycle during which DNA is synthesized. The S-phase fraction may be used with the proliferative index to give a more complete understanding of how fast a tumor is growing."
+                },
+                Pronunciation = new Pronunciation()
+                {
+                    Key = "(... fayz FRAK-shun)",
+                    Audio = "https://nci-media-dev.cancer.gov/audio/pdq/705947.mp3"
+                },
+                Media = new IMedia[] { },
+                RelatedResources = new IRelatedResource[] { }
+            };
+
+            // "cancer.gov" (not the requested "Cancer.gov") and Patient would be the only call to the terms query service, returning the term.
+            termQueryService.Setup(
+                termQSvc => termQSvc.GetById(
+                    It.Is<String>(dictionary => dictionary == "cancer.gov"),
+                    It.Is<AudienceType>(audience => audience == AudienceType.Patient),
+                    It.Is<string>(language => language == "en"),
+                    It.Is<long>(id => id == 44771)
+                )
+            )
+            .Returns(Task.FromResult(glossaryTerm));
+
+            TermsController controller = new TermsController(NullLogger<TermsController>.Instance, termQueryService.Object);
+            GlossaryTerm gsTerm = await controller.GetById("Cancer.gov", AudienceType.Patient, "en", 44771, true);
+
+            // Verify that the expected and actual Term are the same.
+            JObject actual = JObject.Parse(JsonConvert.SerializeObject(gsTerm));
+            JObject expected = JObject.Parse(File.ReadAllText(TestingTools.GetPathToTestFile("TermsControllerData/TestData_GetWithFallback_TermsPatient.json")));
+            Assert.Equal(expected, actual, new JTokenEqualityComparer());
+
+            // Verify that the service layer is called correctly with the fallback logic and lowercased-dictionary fallback combination:
+            termQueryService.Verify(
+                svc => svc.GetById("cancer.gov", AudienceType.Patient, "en", 44771),
+                Times.Once
+            );
+        }
+
+        // This test is for the fallback logic in GetById when the dictionary name is not one that is known (Cancer.gov, Genetics, or NotSet).
+        // Unlike the other fallback tests, this confirms that dictionary and audience combinations that are not known fallback combinations
+        // are identified and cause errors to occur.
+        // This is expected to throw a 404.
+        [Fact]
+        public async void GetById_WithFallback_ErrorMessage_UnknownCombination()
+        {
+            Mock<ITermsQueryService> termQueryService = new Mock<ITermsQueryService>();
+            TermsController controller = new TermsController(NullLogger<TermsController>.Instance, termQueryService.Object);
+            var exception = await Assert.ThrowsAsync<APIErrorException>(() => controller.GetById("UnknownDictionary", AudienceType.Patient, "EN", 10L, true));
+            Assert.Equal(404, exception.HttpStatusCode);
+            Assert.Equal("Could not find initial fallback combination with dictionary 'unknowndictionary' and audience 'Patient'.", exception.Message);
         }
     }
 }


### PR DESCRIPTION
* Update fallback logic to lowercase dictionary param
* Update fallback combinations to use lowercase dictionary param
* Update GetById tests for lower- and title-case params
* Update GetByName tests for lower- and title-case params
* Update integration tests to account for lower- and title-case params