### PR TITLE
(#169) Upgrade to ES 7.17.5

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -125,7 +125,7 @@ jobs:
         env:
             discovery.type: single-node
             ES_JAVA_OPTS: -Xms750m -Xmx750m
-        image: elasticsearch:7.9.2
+        image: elasticsearch:7.17.5
         ports:
           ## NOTE: This will be exposed as a random port referenced below by job.services.elasticsearch.ports[9200]
           - 9200/tcp

--- a/integration-tests/docker-glossary-api/docker-compose.yml
+++ b/integration-tests/docker-glossary-api/docker-compose.yml
@@ -2,9 +2,12 @@ version: "3.7"
 
 services:
     elasticsearch:
-        image: elasticsearch:7.9.2
-        ## All of the ES settings can be set via the environment
-        ## vars.
+        build:
+            # Point to the root of the project.
+            context: ../../
+            # This path is relative to the context.
+            dockerfile: integration-tests/docker-glossary-api/elasticsearch/Dockerfile
+        ## All of the ES settings can be set via the environment vars.
         environment:
             - discovery.type=single-node
             - ES_JAVA_OPTS=-Xms750m -Xmx750m

--- a/integration-tests/docker-glossary-api/elasticsearch/Dockerfile
+++ b/integration-tests/docker-glossary-api/elasticsearch/Dockerfile
@@ -1,6 +1,4 @@
-# Build runtime image
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1
-WORKDIR /app
+FROM elasticsearch:7.17.5
 
 # Get the NIH Root certificates and install them so we work on VPN
 # Download from https://ocio.nih.gov/Smartcard/Pages/PKI_chain.aspx
@@ -8,10 +6,3 @@ RUN mkdir /usr/local/share/ca-certificates/nih \
     && curl -o /usr/local/share/ca-certificates/nih/NIH-DPKI-ROOT-1A-base64.crt https://ocio.nih.gov/Smartcard/Documents/Certificates/NIH-DPKI-ROOT-1A-base64.cer \
     && curl -o /usr/local/share/ca-certificates/nih/NIH-DPKI-CA-1A-base64.crt https://ocio.nih.gov/Smartcard/Documents/Certificates/NIH-DPKI-CA-1A-base64.cer \
     && update-ca-certificates
-
-## This does not need to wait for the loader or other resources.
-## Any integration tests will need to wait for the API to report being healthy
-EXPOSE 5001
-ENV ASPNETCORE_ENVIRONMENT=inttest
-ENV ASPNETCORE_URLS="http://*:5000"
-ENTRYPOINT ["dotnet", "watch", "--project", "src/NCI.OCPL.Api.Glossary", "run"]


### PR DESCRIPTION
Upgrade to Elasticsearch 7.17.5 for security reasons.

Closes #169 