### PR TITLE
(#178) Update NSwag.AspNetCore package version

### DIFF
--- a/src/NCI.OCPL.Api.Glossary/NCI.OCPL.Api.Glossary.csproj
+++ b/src/NCI.OCPL.Api.Glossary/NCI.OCPL.Api.Glossary.csproj
@@ -10,7 +10,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="NSwag.AspNetCore" Version="13.11.*" />
+        <PackageReference Include="NSwag.AspNetCore" Version="13.20.*" />
         <PackageReference Include="NEST" Version="7.9.*" />
         <PackageReference Include="NCI.OCPL.Api.Common" Version="2.1.*" />
     </ItemGroup>


### PR DESCRIPTION
Closes #178 

Testing needs:
- Standard regression tests
- Verify navigating to https://webapis-dev.cancer.gov/glossary/v1/index.html?configUrl=https://jumpy-floor.surge.sh/test.json displays the glossary Swagger page.
