### PR TITLE
(#183, #184) Update to integration testing to Elasticsearch 7.17.28

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   ci_remote:
-    uses: nciocpl/nci.ocpl.api.shared/.github/workflows/common-api-ci.yml@v2.x
+    uses: nciocpl/nci.ocpl.api.shared/.github/workflows/common-api-ci.yml@workflow/v1
     with:
       api-project: src/NCI.OCPL.Api.Glossary/NCI.OCPL.Api.Glossary.csproj
       artifact-name: glossary

--- a/integration-tests/docker-glossary-api/api/Dockerfile
+++ b/integration-tests/docker-glossary-api/api/Dockerfile
@@ -1,5 +1,5 @@
 # Build runtime image
-FROM mcr.microsoft.com/dotnet/sdk:6.0
+FROM mcr.microsoft.com/dotnet/sdk:8.0
 WORKDIR /app
 
 # Get the NIH Root certificates and install them so we work on VPN

--- a/integration-tests/docker-glossary-api/docker-compose.yml
+++ b/integration-tests/docker-glossary-api/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 
 services:
     elasticsearch:

--- a/integration-tests/docker-glossary-api/elasticsearch/Dockerfile
+++ b/integration-tests/docker-glossary-api/elasticsearch/Dockerfile
@@ -1,4 +1,4 @@
-FROM elasticsearch:7.17.5
+FROM elasticsearch:7.17.28
 
 # Get the NIH Root certificates and install them so we work on VPN
 # Download from https://ocio.nih.gov/Smartcard/Pages/PKI_chain.aspx


### PR DESCRIPTION
- Access shared workflow as workflow/v1.
- Update integration testing to use ES 7.17.28
- Update integration test API container to .Net 8.

Closes #183 
Fixes #184 
